### PR TITLE
Run detectors as subprocesses

### DIFF
--- a/rt_eqcorrscan/__init__.py
+++ b/rt_eqcorrscan/__init__.py
@@ -11,6 +11,6 @@ __version__ = '0.0.1a'
 
 
 from rt_eqcorrscan.rt_match_filter import RealTimeTribe
-from rt_eqcorrscan.config.config import Config
+from rt_eqcorrscan.config.config import Config, read_config
 from rt_eqcorrscan.database.database_manager import TemplateBank
 from rt_eqcorrscan.reactor.reactor import Reactor

--- a/rt_eqcorrscan/config/config.py
+++ b/rt_eqcorrscan/config/config.py
@@ -286,26 +286,35 @@ class Config(object):
                 _dict.update({key: value})
         return _dict
 
-    def setup_logging(self, **kwargs):
+    def setup_logging(
+        self,
+        screen: bool = True,
+        file: bool = True,
+        filename: str = "rt_eqcorrscan.log",
+        **kwargs
+    ):
         """Set up logging using the logging parameters."""
-        file_log_args = dict(filename="rt_eqcorrscan.log", mode='a',
-                             maxBytes=20*1024*1024, backupCount=2,
-                             encoding=None, delay=0)
-        file_log_args.update(kwargs)
-        rotating_handler = RotatingFileHandler(**file_log_args)
-        rotating_handler.setFormatter(
-            logging.Formatter(self.log_formatter))
-        rotating_handler.setLevel(logging.DEBUG)
-        # Console handler
-        console_handler = logging.StreamHandler(stream=sys.stdout)
-        console_handler.setLevel(self.log_level)
-        console_handler.setFormatter(
-            logging.Formatter(self.log_formatter))
-        # logging.basicConfig(
-        #     level=self.log_level, format=self.log_formatter,
-        #     handlers=[rotating_handler, console_handler])
+        handlers = []
+        if file:
+            file_log_args = dict(filename=filename, mode='a',
+                                 maxBytes=20*1024*1024, backupCount=2,
+                                 encoding=None, delay=0)
+            file_log_args.update(kwargs)
+            rotating_handler = RotatingFileHandler(**file_log_args)
+            rotating_handler.setFormatter(
+                logging.Formatter(self.log_formatter))
+            rotating_handler.setLevel(self.log_level)
+            handlers.append(rotating_handler)
+        if screen:
+            # Console handler
+            console_handler = logging.StreamHandler(stream=sys.stdout)
+            console_handler.setLevel(self.log_level)
+            console_handler.setFormatter(
+                logging.Formatter(self.log_formatter))
+            handlers.append(console_handler)
         logging.basicConfig(
-            level=self.log_level, format=self.log_formatter)
+            level=self.log_level, format=self.log_formatter,
+            handlers=handlers)
 
 
 def read_config(config_file=None) -> Config:

--- a/rt_eqcorrscan/config/config.py
+++ b/rt_eqcorrscan/config/config.py
@@ -215,7 +215,7 @@ class DatabaseManagerConfig(_ConfigAttribDict):
     defaults = {
         "event_path": ".",
         "event_format": "QUAKEML",
-        "event_name_structure": "{event_id_end}",
+        "name_structure": "{event_id_end}",
         "path_structure": "{year}/{month}/{event_id_end}",
         "event_ext": ".xml",
         "min_stations": 5,

--- a/rt_eqcorrscan/config/config.py
+++ b/rt_eqcorrscan/config/config.py
@@ -54,7 +54,8 @@ class RTMatchFilterConfig(_ConfigAttribDict):
     defaults = {
         "client": "GEONET",
         "client_type": "FDSN",
-        "seedlink_server_url": "link.geonet.org.nz",
+        "rt_client_url": "link.geonet.org.nz",
+        "rt_client_type": "seedlink",
         "n_stations": 10,
         "min_stations": 5,
         "max_distance": 1000.,
@@ -107,6 +108,25 @@ class RTMatchFilterConfig(_ConfigAttribDict):
             Logger.error(e)
             return None
         return client
+
+    def get_streaming_client(self):
+        """ Get the configured waveform streaming service. """
+        from rt_eqcorrscan.streaming import clients
+
+        try:
+            _client_module = clients.__getattribute__(
+                self.rt_client_type.lower())
+        except AttributeError as e:
+            Logger.error(e)
+            return None
+        try:
+            rt_client = _client_module.RealTimeClient(
+                server_url=self.rt_client_url,
+                buffer_capacity=self.buffer_capacity)
+        except Exception as e:
+            Logger.error(e)
+            return None
+        return rt_client
 
 
 class ReactorConfig(_ConfigAttribDict):

--- a/rt_eqcorrscan/database/client_emulation.py
+++ b/rt_eqcorrscan/database/client_emulation.py
@@ -36,9 +36,9 @@ class ClientBank(object):
     """
     def __init__(
         self,
-        wave_bank: Union[Client, WaveBank],
-        event_bank: Union[Client, EventBank],
-        station_bank: Union[Client, StationBank],
+        wave_bank: Union[Client, WaveBank] = None,
+        event_bank: Union[Client, EventBank] = None,
+        station_bank: Union[Client, StationBank] = None,
     ):
         self.wave_bank = wave_bank
         self.station_bank = station_bank
@@ -46,18 +46,28 @@ class ClientBank(object):
         self.base_url = "I'm not a real client!"
 
     def get_stations(self, *args, **kwargs):
+        if self.station_bank is None:
+            raise NotImplementedError("No station_bank provided")
         return self.station_bank.get_stations(*args, **kwargs)
 
     def get_stations_bulk(self, *args, **kwargs):
+        if self.station_bank is None:
+            raise NotImplementedError("No station_bank provided")
         return self.station_bank.get_stations_bulk(*args, **kwargs)
 
     def get_waveforms(self, *args, **kwargs):
+        if self.wave_bank is None:
+            raise NotImplementedError("No wave_bank provided")
         return self.wave_bank.get_waveforms(*args, **kwargs)
 
     def get_waveforms_bulk(self, *args, **kwargs):
+        if self.wave_bank is None:
+            raise NotImplementedError("No wave_bank provided")
         return self.wave_bank.get_waveforms_bulk(*args, **kwargs)
 
     def get_events(self, *args, **kwargs):
+        if self.event_bank is None:
+            raise NotImplementedError("No event_bank provided")
         return self.event_bank.get_events(*args, **kwargs)
 
 

--- a/rt_eqcorrscan/database/database_manager.py
+++ b/rt_eqcorrscan/database/database_manager.py
@@ -205,16 +205,12 @@ class TemplateBank(EventBank):
             event_id_short
         If no structure is provided it will be read from the index, if no
         index exists the default is {year}/{month}/{day}
-    event_name_structure : str
-        The same as path structure but for the event file name. Supports the
-        same variables and a slash cannot be used in a file name on most
-        operating systems. The default extension (.xml) will be added.
-        The default is {time}_{event_id_short}.
-    template_name_structure
-        The same as path structure but for the template file name. Supports the
-        same variables and a slash cannot be used in a file name on most
-        operating systems. The default extension (.tgz) will be added.
-        The default is to use the same naming as event_name_structure.
+    name_structure : str
+        The same as path structure but for the event, template and waveform
+        file names. Supports the same variables and a slash cannot be used
+        in a file name on most operating systems. The default extension
+        (.xml, .tgz, .ms) will be added for events, templates and waveforms
+        respectively. The default is {time}_{event_id_short}.
     event_format
         The anticipated format of the event files. Any format supported by the
         obspy.read_events function is permitted.
@@ -239,8 +235,7 @@ class TemplateBank(EventBank):
         self,
         base_path: Union[str, Path, "EventBank"] = ".",
         path_structure: Optional[str] = None,
-        event_name_structure: Optional[str] = None,
-        template_name_structure: Optional[str] = None,
+        name_structure: Optional[str] = None,
         cache_size: int = 5,
         event_format="quakeml",
         event_ext=".xml",
@@ -250,13 +245,9 @@ class TemplateBank(EventBank):
         """Initialize the bank."""
         super().__init__(
             base_path=base_path, path_structure=path_structure,
-            name_structure=event_name_structure, cache_size=cache_size,
+            name_structure=name_structure, cache_size=cache_size,
             format=event_format, ext=event_ext)
         self.template_ext = template_ext
-        # get waveform structure based on structures of path and filename
-        wns = (template_name_structure or self._name_structure or
-               EVENT_NAME_STRUCTURE)
-        self.template_name_structure = wns
         self.executor = executor or _SerialExecutor()
 
     @compose_docstring(get_events_params=get_events_parameters)
@@ -297,7 +288,7 @@ class TemplateBank(EventBank):
         self.put_events(catalog, update_index=update_index)
         inner_put_template = partial(
             _put_template, path_structure=self.path_structure,
-            template_name_structure=self.template_name_structure,
+            template_name_structure=self.name_structure,
             bank_path=self.bank_path)
         _ = [_ for _ in self.executor.map(inner_put_template, templates)]
 
@@ -368,7 +359,7 @@ class TemplateBank(EventBank):
                 download_data_len=download_data_len,
                 path_structure=self.path_structure,
                 bank_path=self.bank_path,
-                template_name_structure=self.template_name_structure,
+                template_name_structure=self.name_structure,
                 save_raw=save_raw, rebuild=rebuild, **kwargs)
             template_iterable = self.executor.map(
                 inner_download_and_make_template, catalog)

--- a/rt_eqcorrscan/database/database_manager.py
+++ b/rt_eqcorrscan/database/database_manager.py
@@ -373,7 +373,9 @@ class TemplateBank(EventBank):
             template_iterable = self.executor.map(
                 inner_download_and_make_template, catalog)
             tribe = Tribe([t for t in template_iterable if t is not None])
+        Logger.info(f"Putting {len(tribe)} templates into database")
         self.put_templates(tribe, update_index=update_index)
+        Logger.info("Finished putting templates into database.")
         return tribe
 
 

--- a/rt_eqcorrscan/database/database_manager.py
+++ b/rt_eqcorrscan/database/database_manager.py
@@ -269,7 +269,7 @@ class TemplateBank(EventBank):
 
         {get_event_params}
         """
-        paths = self.bank_path + self.read_index(
+        paths = str(self.bank_path) + self.read_index(
             columns=["path", "latitude", "longitude"], **kwargs).path
         paths = [path.replace(self.ext, self.template_ext) for path in paths]
         future = self.executor.map(_lazy_template_read, paths)
@@ -294,13 +294,7 @@ class TemplateBank(EventBank):
         for t in templates:
             assert(isinstance(t, Template))
         catalog = Catalog([t.event for t in templates])
-        # Temporary blocking of parallel processing in obsplus put_events,
-        # see https://github.com/niosh-mining/obsplus/issues/158
-        _exec = self.executor
-        self.executor = None
         self.put_events(catalog, update_index=update_index)
-        self.executor = _exec
-        # End of temporary blocking
         inner_put_template = partial(
             _put_template, path_structure=self.path_structure,
             template_name_structure=self.template_name_structure,

--- a/rt_eqcorrscan/reactor/__init__.py
+++ b/rt_eqcorrscan/reactor/__init__.py
@@ -7,4 +7,5 @@ License
     GPL v3.0
 """
 
-from .reactor import estimate_region, get_inventory, Reactor
+from .reactor import estimate_region, Reactor
+from .spin_up import get_inventory

--- a/rt_eqcorrscan/reactor/reactor.py
+++ b/rt_eqcorrscan/reactor/reactor.py
@@ -195,9 +195,13 @@ class Reactor(object):
                     eventid=added_ids)
                 if len(tribe) > 0:
                     Logger.info(f"Adding {len(tribe)} events to {triggering_event_id}")
-                    tribe.write(os.path.join(
+                    tribe_file = os.path.join(
                         _get_triggered_working_dir(triggering_event_id),
-                        "tribe.tgz"))
+                        "tribe.tgz")
+                    while os.path.isfile(tribe_file):
+                        time.sleep(0.2)  # Wait until the tribe-file is removed by the subprocess
+                    tribe.write(tribe_file)
+                    Logger.info(f"Written new templates to {tribe_file}")
                     self._running_templates[triggering_event_id].update(
                         added_ids)
         trigger_events = self.trigger_func(new_events)

--- a/rt_eqcorrscan/reactor/reactor.py
+++ b/rt_eqcorrscan/reactor/reactor.py
@@ -168,7 +168,7 @@ class Reactor(object):
             for triggering_event_id, tribe_region in self._running_regions.items():
                 add_events = get_events(working_cat, **tribe_region)
                 # TODO: Implement region growth based on new events added.
-                added_ids = {e.resource_id.id.split('/') for e in add_events}
+                added_ids = {e.resource_id.id.split('/')[-1] for e in add_events}
                 if added_ids:
                     tribe = self.template_database.get_templates(
                         event_ids=added_ids)

--- a/rt_eqcorrscan/reactor/reactor.py
+++ b/rt_eqcorrscan/reactor/reactor.py
@@ -163,6 +163,7 @@ class Reactor(object):
                 working_cat = []
             Logger.debug("Currently analysing a catalog of {0} events".format(
                 len(working_cat)))
+            # TODO: Abstract out into "process_events" method, which simulate can call.
             # Check if new events should be in one of the already running
             # tribes and add them.
             for triggering_event_id, tribe_region in self._running_regions.items():

--- a/rt_eqcorrscan/reactor/reactor.py
+++ b/rt_eqcorrscan/reactor/reactor.py
@@ -9,30 +9,34 @@ License
 import logging
 import time
 import gc
+import os
+import subprocess
 
-from collections import Counter
-from typing import Union, Callable
+from typing import Callable, Iterable
 from multiprocessing import cpu_count
 
-from obspy import Inventory, UTCDateTime
+from obspy import UTCDateTime
 from obspy.core.event import Event
-from obspy.clients.fdsn.client import FDSNNoDataException
-from obspy.geodetics import locations2degrees, kilometer2degrees
 
 from obsplus.events import get_events
 
-from eqcorrscan import Tribe, Party
-
-from rt_eqcorrscan.database.database_manager import (
-    TemplateBank, check_tribe_quality)
-from rt_eqcorrscan.rt_match_filter import RealTimeTribe
+from rt_eqcorrscan.database.database_manager import TemplateBank
 from rt_eqcorrscan.event_trigger.catalog_listener import CatalogListener
-from rt_eqcorrscan.event_trigger.listener import event_time
 from rt_eqcorrscan.streaming.streaming import _StreamingClient
-from rt_eqcorrscan.config import Notifier
+from rt_eqcorrscan.config import Notifier, Config
 
 
 Logger = logging.getLogger(__name__)
+
+
+def _get_triggered_working_dir(
+        triggering_event_id: str,
+        exist_ok: bool = True
+) -> str:
+    working_dir = os.path.join(
+        os.path.abspath(os.getcwd()), triggering_event_id)
+    os.makedirs(working_dir, exist_ok=exist_ok)
+    return working_dir
 
 
 class Reactor(object):
@@ -61,17 +65,8 @@ class Reactor(object):
     template_database
         A template database to be used to generate tribes for real-time
         matched-filter detection.
-    template_lookup_kwargs
-        Keyword arguments passed to get_templates - regional arguments will be
-        set based on the triggering event.
-    listener_kwargs
-        Dictionary of keyword arguments to be passed to listener.run
-    real_time_tribe_kwargs
-        Dictionary of keyword arguments for the real-time tribe. Any keys not
-        included will be set to default values.
-    plot_kwargs
-        Dictionary of plotting keyword arguments - only required if `plot=True`
-        in `real_time_tribe_kwargs`.
+    config
+        Configuration for RT-EQcorrscan.
     notifier
         Notifier that will send messages about triggers.
 
@@ -91,15 +86,14 @@ class Reactor(object):
     ```
     """
     triggered_events = []
-    _plotting = None  # Place to store the triggering_id of a plotting tribe.
-    running_tribes = dict()
     running_template_ids = set()
+    running_regions = dict()
     max_station_distance = 1000
     n_stations = 10
     sleep_step = 15
 
-    # The threads that are detecting away!
-    detecting_processes = []
+    # The processes that are detecting away!
+    detecting_processes = dict()
     # TODO: Build in an AWS spin-up functionality - would need some communication...
 
     def __init__(
@@ -109,10 +103,7 @@ class Reactor(object):
         listener: CatalogListener,
         trigger_func: Callable,
         template_database: TemplateBank,
-        template_lookup_kwargs: dict,
-        listener_kwargs: dict,
-        real_time_tribe_kwargs: dict,
-        plot_kwargs: dict,
+        config: Config,
         notifier: Notifier = None,
     ):
         self.client = client
@@ -120,10 +111,10 @@ class Reactor(object):
         self.listener = listener
         self.trigger_func = trigger_func
         self.template_database = template_database
-        self.template_lookup_kwargs = template_lookup_kwargs
-        self.real_time_tribe_kwargs = real_time_tribe_kwargs
-        self.plot_kwargs = plot_kwargs
-        self.listener_kwargs = listener_kwargs
+        self.config = config
+        self._listener_kwargs = dict(
+            min_stations=config.database_manager.min_stations,
+            template_kwargs=config.template)
         self.notifier = notifier or Notifier()
         # Time-keepers
         self._run_start = None
@@ -144,24 +135,11 @@ class Reactor(object):
 
     up_time = property(get_up_time, set_up_time)
 
-    def run(
-        self,
-        max_run_length: float = None,
-        maximum_backfill: float = None,
-    ) -> None:
+    def run(self) -> None:
         """
         Run all the processes.
-
-        Parameters
-        ----------
-        max_run_length
-            Maximum run length for the reactor - will stop if run-time reaches
-            this point. Units: seconds
-        maximum_backfill
-            Maximum back-fill length for new templates being added to already
-            running tribes. Units: seconds
         """
-        self.listener.background_run(**self.listener_kwargs)
+        self.listener.background_run(**self._listener_kwargs)
         self._run_start = UTCDateTime.now()
         # Query the catalog in the listener every so often and check
         while True:
@@ -173,17 +151,17 @@ class Reactor(object):
                 working_cat = []
             Logger.debug("Currently analysing a catalog of {0} events".format(
                 len(working_cat)))
-
             # Check if new events should be in one of the already running
             # tribes and add them.
-            for tribe_region in self.running_tribes.values():
-                add_events = get_events(working_cat, **tribe_region["region"])
-                added_ids = tribe_region["tribe"].add_templates([
-                    self.template_database.get_templates(
-                        eventid=e.resource_id) for e in add_events],
-                    maximum_backfill=maximum_backfill,
-                    **self.real_time_tribe_kwargs)
+            for triggering_event_id, tribe_region in self.running_regions.items():
+                add_events = get_events(working_cat, **tribe_region)
+                added_ids = [e.resource_id.split('/') for e in add_events]
                 if added_ids:
+                    tribe = self.template_database.get_templates(
+                        event_ids=added_ids)
+                    tribe.write(os.path.join(
+                        _get_triggered_working_dir(triggering_event_id),
+                        "tribe.tgz"))
                     self.running_template_ids.update(added_ids)
                     working_cat.events = [e for e in working_cat
                                           if e not in add_events]
@@ -198,109 +176,49 @@ class Reactor(object):
                             trigger_event),
                         level=5)
                     self.triggered_events.append(trigger_event)
-                    self.background_spin_up(trigger_event)
+                    self.spin_up(trigger_event)
             self.set_up_time(UTCDateTime.now())
-            if max_run_length and self.up_time >= max_run_length:
-                Logger.info("Times up: Stopping")
-                self.stop()
-                break
-            gc.collect()
             time.sleep(self.sleep_step)
 
     def spin_up(
         self,
         triggering_event: Event,
-        run: bool = True,
-    ) -> Union[Party, tuple]:
+    ):
         """
-        Run the reactors response function.
+        Run the reactors response function as a subprocess.
 
         Parameters
         ----------
         triggering_event
             Event that triggered this run - needs to have at-least an origin.
-        run
-            Whether to run the real-time tribe immediately (True),
-            or return it (False).
         """
-        min_stations = self.listener_kwargs.get("min_stations", None)
+        triggering_event_id = triggering_event.resource_id.split('/')[-1]
         region = estimate_region(triggering_event)
         if region is None:
             return None, None
-        region.update(self.template_lookup_kwargs)
+        region.update(
+            {"starttime": self.config.database_manager.lookup_starttime})
         Logger.info("Getting templates within {0}".format(region))
-        tribe = self.template_database.get_templates(**region)
-        Logger.info("Read in {0} templates".format(len(tribe)))
-        tribe.templates = [t for t in tribe
-                           if t.name not in self.running_template_ids]
-        if len(tribe) == 0:
-            Logger.warning("No appropriate templates for event: {0}".format(
-                region))
-            return None, None
-        Logger.info("Checking tribe quality: removing templates with "
-                    "fewer than {0} stations".format(min_stations))
-        tribe = check_tribe_quality(
-            tribe, min_stations=min_stations,
-            **self.listener_kwargs["template_kwargs"])
-        Logger.info("Tribe now contains {0} templates".format(len(tribe)))
-        if len(tribe) == 0:
-            return None, None
-        inventory = get_inventory(
-            self.client, tribe, triggering_event=triggering_event,
-            max_distance=self.max_station_distance,
-            n_stations=self.n_stations)
-        detect_interval = self.real_time_tribe_kwargs.get(
-            "detect_interval", 60)
-        plot = self.real_time_tribe_kwargs.get("plot", False)
-        if plot and self._plotting is not None:
-            Logger.warning(
-                "Cannot plot for more than one real-time-tribe at once.")
-            plot = False
-        elif plot:
-            self._plotting = triggering_event.resource_id
-        real_time_tribe = RealTimeTribe(
-            tribe=tribe, inventory=inventory, rt_client=self.rt_client.copy(),
-            detect_interval=detect_interval, plot=plot,
-            plot_options=self.plot_kwargs,
-            name=triggering_event.resource_id.id.split('/')[-1])
-        Logger.info("Created real-time tribe with inventory:\n{0}".format(
-            inventory))
-        real_time_tribe.notifier = self.notifier
-
-        real_time_tribe_kwargs = {
-            "backfill_to": event_time(triggering_event),
-            "backfill_client": self.listener.waveform_client,
-            "cores": self.available_cores}
-        real_time_tribe_kwargs.update(self.real_time_tribe_kwargs)
-        self.running_tribes.update(
-            {triggering_event.resource_id.id:
-             {"tribe": real_time_tribe, "region": region}})
-        self.running_template_ids.update({t.name for t in real_time_tribe})
-        if run:
-            return real_time_tribe.run(**real_time_tribe_kwargs)
-        else:
-            return real_time_tribe, real_time_tribe_kwargs
-
-    def background_spin_up(
-        self,
-        triggering_event: Event,
-    ) -> None:
-        """
-        Spin up a detection run in a background process.
-
-        Parameters
-        ----------
-        triggering_event
-            Event that triggered this run - needs to have at-least an origin.
-        """
-        real_time_tribe, real_time_tribe_kwargs = self.spin_up(
-            triggering_event=triggering_event, run=False)
-        if real_time_tribe is None:
+        df = self.template_database.get_event_summary(**region)
+        event_ids = {e.split('/')[-1] for e in df["event_id"]}
+        event_ids = event_ids.difference(self.running_template_ids)
+        # Write file of event id's
+        if len(event_ids) == 0:
             return
-        Logger.info("Starting real-time tribe")
-        real_time_tribe.background_run(**real_time_tribe_kwargs)
-        self.detecting_processes.append(real_time_tribe._detecting_thread)
-        Logger.info("Started detector thread - continuing listening")
+        working_dir = _get_triggered_working_dir(
+            triggering_event_id, exist_ok=False)
+        tribe = self.template_database.get_templates(event_ids=event_ids)
+        tribe.write(os.path.join(working_dir, "tribe.tgz"))
+        self.config.write(
+            os.path.join(working_dir, 'rt_eqcorrscan_config.yml'))
+        triggering_event.write(
+            os.path.join(working_dir, 'triggering_event.xml'), format="QUAKEML")
+        script_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "spin_up.py")
+        proc = subprocess.Popen(["python", script_path, "-w", working_dir])
+        self.detecting_processes.update({triggering_event_id: proc})
+        self.running_regions.update({triggering_event_id: region})
+        Logger.info("Started detector subprocess - continuing listening")
 
     def stop_tribe(self, triggering_event_id: str = None) -> None:
         """
@@ -313,123 +231,15 @@ class Reactor(object):
         """
         if triggering_event_id is None:
             return self.stop()
-        tribe_to_stop = self.running_tribes[triggering_event_id]["tribe"]
-        tribe_to_stop.stop()
-        # TODO: stop the detecting thread if it is running in the background.
-        tribe_thread = [
-            thread for thread in self.detecting_processes
-            if thread.name.endswith(triggering_event_id.split('/')[-1])][0]
-        tribe_thread.join()
-        self.running_tribes.pop(triggering_event_id)
-        if self._plotting == triggering_event_id:
-            self._plotting = None  # Allow new plots
+        self.detecting_processes[triggering_event_id].kill()
+        self.detecting_processes.pop(triggering_event_id)
         return None
 
     def stop(self) -> None:
         """Stop all the processes."""
-        for event_id in self.running_tribes.keys():
+        for event_id in self.detecting_processes.keys():
             self.stop_tribe(event_id)
-        for detecting_thread in self.detecting_processes:
-            detecting_thread.join()
         self.listener.background_stop()
-
-
-def get_inventory(
-        client,
-        tribe: Union[RealTimeTribe, Tribe],
-        triggering_event: Event = None,
-        location: dict = None,
-        starttime: UTCDateTime = None,
-        max_distance: float = 1000.,
-        n_stations: int = 10,
-        duration: float = 10,
-        level: str = "channel",
-        channel_list: Union[list, tuple] = ("EH?", "HH?"),
-) -> Inventory:
-    """
-    Get a suitable inventory for a tribe - selects the most used, closest
-    stations.
-
-
-    Parameters
-    ----------
-    client:
-        Obspy client with a get_stations service.
-    tribe:
-        Tribe or RealTimeTribe of templates to query for stations.
-    triggering_event:
-        Event with at least an origin to calculate distances from - if not
-        specified will use `location`
-    location:
-        Dictionary with "latitude" and "longitude" keys - only used if
-        `triggering event` is not specified.
-    starttime:
-        Start-time for station search - only used if `triggering_event` is
-        not specified.
-    max_distance:
-        Maximum distance from `triggering_event.preferred_origin` or
-        `location` to find stations. Units: km
-    n_stations:
-        Maximum number of stations to return
-    duration:
-        Duration stations must be active for. Units: days
-    level:
-        Level for inventory parsable by `client.get_stations`.
-    channel_list
-        List of channel-codes to be acquired.  If `None` then all channels
-        will be searched.
-
-    Returns
-    -------
-    Inventory of the most used, closest stations.
-    """
-    inv = Inventory(networks=[], source=None)
-    if triggering_event is not None:
-        try:
-            origin = (
-                triggering_event.preferred_origin() or
-                triggering_event.origins[0]
-            )
-        except IndexError:
-            Logger.error("Triggering event has no origin")
-            return inv
-        lat = origin.latitude
-        lon = origin.longitude
-        _starttime = origin.time
-    else:
-        lat = location["latitude"]
-        lon = location["longitude"]
-        _starttime = starttime
-
-    for channel_str in channel_list or ["*"]:
-        try:
-            inv += client.get_stations(
-                startbefore=_starttime,
-                endafter=_starttime + (duration * 86400),
-                channel=channel_str, latitude=lat,
-                longitude=lon,
-                maxradius=kilometer2degrees(max_distance),
-                level=level)
-        except FDSNNoDataException:
-            continue
-    if len(inv) == 0:
-        return inv
-    # Calculate distances
-    station_count = Counter(
-        [pick.waveform_id.station_code for template in tribe
-         for pick in template.event.picks])
-
-    sta_dist = []
-    for net in inv:
-        for sta in net:
-            dist = locations2degrees(
-                lat1=lat, long1=lon, lat2=sta.latitude, long2=sta.longitude)
-            sta_dist.append((sta.code, dist, station_count[sta.code]))
-    sta_dist.sort(key=lambda _: (-_[2], _[1]))
-    inv_out = inv.select(station=sta_dist[0][0])
-    for sta in sta_dist[1:n_stations]:
-        inv_out += inv.select(station=sta[0])
-    return inv_out
 
 
 def estimate_region(event: Event, min_length: float = 50.) -> dict:

--- a/rt_eqcorrscan/reactor/reactor.py
+++ b/rt_eqcorrscan/reactor/reactor.py
@@ -226,7 +226,7 @@ class Reactor(object):
         if len(event_ids) == 0:
             return
         working_dir = _get_triggered_working_dir(
-            triggering_event_id, exist_ok=False)
+            triggering_event_id, exist_ok=True)
         tribe = self.template_database.get_templates(event_ids=event_ids)
         tribe.write(os.path.join(working_dir, "tribe.tgz"))
         self.config.write(
@@ -235,9 +235,10 @@ class Reactor(object):
             os.path.join(working_dir, 'triggering_event.xml'), format="QUAKEML")
         script_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "spin_up.py")
-        proc = subprocess.Popen(
-            ["python", script_path, "-w", working_dir,
-             "-n", min(self.available_cores, self._max_detect_cores)])
+        _call = ["python", script_path, "-w", working_dir,
+                 "-n", str(min(self.available_cores, self._max_detect_cores))]
+        Logger.info(f"Running {_call}")
+        proc = subprocess.Popen(_call)
         self.detecting_processes.update({triggering_event_id: proc})
         self._running_regions.update({triggering_event_id: region})
         self._running_templates.update(

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -39,9 +39,10 @@ def run(working_dir: str, cores: int = 1):
     config = read_config('rt_eqcorrscan_config.yml')
     config.setup_logging(
         screen=False, file=True,
-        filename="rt_eqcorrscan_{0}.log".format(
+        filename="{0}/rt_eqcorrscan_{1}.log".format(
+            working_dir,
             os.path.split(working_dir)[-1]))
-    triggering_event = read_events('triggering_event.xml')
+    triggering_event = read_events('triggering_event.xml')[0]
     min_stations = config.rt_match_filter.get("min_stations", None)
     tribe = Tribe().read("tribe.tgz")
     # Remove file to avoid re-reading it

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -25,7 +25,7 @@ from rt_eqcorrscan.database.database_manager import check_tribe_quality
 from rt_eqcorrscan.event_trigger.listener import event_time
 
 
-Logger = logging.getLevelName(__file__)
+Logger = logging.getLogger(__file__)
 
 
 def _read_event_list(fname: str) -> List[str]:
@@ -152,8 +152,7 @@ def get_inventory(
         try:
             origin = (
                 triggering_event.preferred_origin() or
-                triggering_event.origins[0]
-            )
+                triggering_event.origins[0])
         except IndexError:
             Logger.error("Triggering event has no origin")
             return inv

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -61,7 +61,7 @@ def run(working_dir: str, cores: int = 1):
         return None, None
 
     client = config.rt_match_filter.get_client()
-    rt_client = config.rt_match_filter.get_streaming_client()
+    rt_client = config.streaming.get_streaming_client()
 
     inventory = get_inventory(
         client, tribe, triggering_event=triggering_event,
@@ -71,7 +71,7 @@ def run(working_dir: str, cores: int = 1):
         "detect_interval", 60)
     plot = config.rt_match_filter.get("plot", False)
     real_time_tribe = RealTimeTribe(
-        tribe=tribe, inventory=inventory, rt_client=rt_client.copy(),
+        tribe=tribe, inventory=inventory, rt_client=rt_client,
         detect_interval=detect_interval, plot=plot,
         plot_options=config.plot,
         name=triggering_event.resource_id.id.split('/')[-1])

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -75,6 +75,8 @@ def run(working_dir: str, cores: int = 1):
         detect_interval=detect_interval, plot=plot,
         plot_options=config.plot,
         name=triggering_event.resource_id.id.split('/')[-1])
+    real_time_tribe._parallel_processing = False
+    # Disable parallel processing for subprocess
     Logger.info("Created real-time tribe with inventory:\n{0}".format(
         inventory))
 

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+"""
+Functions for spinning up and running a real-time tribe based on trigger-events
+
+Author
+    Calum J Chamberlain
+License
+    GPL v3.0
+"""
+
+"""
+Needs to be standalone as a subprocess.
+
+TODO:
+1. Read in configuration - read from file
+2. Read in tribe - read event-ids from a file, every loop, check for new events
+3. Write a "running-templates" file
+4. Set-up logging
+5. Run the detector.
+6. Run new templates through old data and add those detections.
+"""
+import os
+import logging
+
+from collections import Counter
+from typing import List, Union
+
+from obspy import read_events, Inventory, UTCDateTime
+from obspy.core.event import Event
+from obspy.clients.fdsn.client import FDSNNoDataException
+from obspy.geodetics import locations2degrees, kilometer2degrees
+from eqcorrscan import Tribe
+
+from rt_eqcorrscan import read_config, RealTimeTribe
+from rt_eqcorrscan.database.database_manager import check_tribe_quality
+from rt_eqcorrscan.event_trigger.listener import event_time
+
+
+Logger = logging.getLevelName(__file__)
+
+
+def _read_event_list(fname: str) -> List[str]:
+    with open(fname, "r") as f:
+        event_ids = [line.strip() for line in f]
+    return event_ids
+
+
+# TODO: Make this work!
+def run(working_dir: str):
+    os.chdir(working_dir)
+    config = read_config('rt_eqcorrscan_config.yml')
+    config.setup_logging(
+        screen=False, file=True,
+        filename="rt_eqcorrscan_{0}.log".format(
+            os.path.split(working_dir)[-1]))
+    triggering_event = read_events('triggering_event.xml')
+    min_stations = config.rt_match_filter.get("min_stations", None)
+    tribe = Tribe().read("tribe.tgz")
+    # Remove file to avoid re-reading it
+    os.remove("tribe.tgz")
+
+    Logger.info("Read in {0} templates".format(len(tribe)))
+    if len(tribe) == 0:
+        Logger.warning("No appropriate templates found")
+        return
+    Logger.info("Checking tribe quality: removing templates with "
+                "fewer than {0} stations".format(min_stations))
+    tribe = check_tribe_quality(
+        tribe, min_stations=min_stations, **config.template)
+    Logger.info("Tribe now contains {0} templates".format(len(tribe)))
+    if len(tribe) == 0:
+        return None, None
+
+    client = config.rt_match_filter.get_client()
+    rt_client = "bob"  # TODO: How to make this work?
+
+    inventory = get_inventory(
+        client, tribe, triggering_event=triggering_event,
+        max_distance=config.rt_match_filter.max_distance,
+        n_stations=config.rt_match_filter.n_stations)
+    detect_interval = config.rt_match_filter.get(
+        "detect_interval", 60)
+    plot = config.rt_match_filter.get("plot", False)
+    real_time_tribe = RealTimeTribe(
+        tribe=tribe, inventory=inventory, rt_client=rt_client.copy(),
+        detect_interval=detect_interval, plot=plot,
+        plot_options=config.plot,
+        name=triggering_event.resource_id.id.split('/')[-1])
+    Logger.info("Created real-time tribe with inventory:\n{0}".format(
+        inventory))
+
+    real_time_tribe.notifier = None  # TODO: How will this work?
+
+    real_time_tribe_kwargs = {
+        "backfill_to": event_time(triggering_event),
+        "backfill_client": config.listener.waveform_client,  # TODO: And this?
+        "cores": 1e99}  # TODO: How to make this work?
+
+
+def get_inventory(
+        client,
+        tribe: Union[RealTimeTribe, Tribe],
+        triggering_event: Event = None,
+        location: dict = None,
+        starttime: UTCDateTime = None,
+        max_distance: float = 1000.,
+        n_stations: int = 10,
+        duration: float = 10,
+        level: str = "channel",
+        channel_list: Union[list, tuple] = ("EH?", "HH?"),
+) -> Inventory:
+    """
+    Get a suitable inventory for a tribe - selects the most used, closest
+    stations.
+
+
+    Parameters
+    ----------
+    client:
+        Obspy client with a get_stations service.
+    tribe:
+        Tribe or RealTimeTribe of templates to query for stations.
+    triggering_event:
+        Event with at least an origin to calculate distances from - if not
+        specified will use `location`
+    location:
+        Dictionary with "latitude" and "longitude" keys - only used if
+        `triggering event` is not specified.
+    starttime:
+        Start-time for station search - only used if `triggering_event` is
+        not specified.
+    max_distance:
+        Maximum distance from `triggering_event.preferred_origin` or
+        `location` to find stations. Units: km
+    n_stations:
+        Maximum number of stations to return
+    duration:
+        Duration stations must be active for. Units: days
+    level:
+        Level for inventory parsable by `client.get_stations`.
+    channel_list
+        List of channel-codes to be acquired.  If `None` then all channels
+        will be searched.
+
+    Returns
+    -------
+    Inventory of the most used, closest stations.
+    """
+    inv = Inventory(networks=[], source=None)
+    if triggering_event is not None:
+        try:
+            origin = (
+                triggering_event.preferred_origin() or
+                triggering_event.origins[0]
+            )
+        except IndexError:
+            Logger.error("Triggering event has no origin")
+            return inv
+        lat = origin.latitude
+        lon = origin.longitude
+        _starttime = origin.time
+    else:
+        lat = location["latitude"]
+        lon = location["longitude"]
+        _starttime = starttime
+
+    for channel_str in channel_list or ["*"]:
+        try:
+            inv += client.get_stations(
+                startbefore=_starttime,
+                endafter=_starttime + (duration * 86400),
+                channel=channel_str, latitude=lat,
+                longitude=lon,
+                maxradius=kilometer2degrees(max_distance),
+                level=level)
+        except FDSNNoDataException:
+            continue
+    if len(inv) == 0:
+        return inv
+    # Calculate distances
+    station_count = Counter(
+        [pick.waveform_id.station_code for template in tribe
+         for pick in template.event.picks])
+
+    sta_dist = []
+    for net in inv:
+        for sta in net:
+            dist = locations2degrees(
+                lat1=lat, long1=lon, lat2=sta.latitude, long2=sta.longitude)
+            sta_dist.append((sta.code, dist, station_count[sta.code]))
+    sta_dist.sort(key=lambda _: (-_[2], _[1]))
+    inv_out = inv.select(station=sta_dist[0][0])
+    for sta in sta_dist[1:n_stations]:
+        inv_out += inv.select(station=sta[0])
+    return inv_out
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Script to spin-up a real-time matched-filter instance")
+
+    parser.add_argument(
+        "-w", "--working-dir", type=str,
+        help="Working directory containing configuration file, list of "
+             "templates and place to store temporary files")

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -104,7 +104,7 @@ class RealTimeTribe(Tribe):
 
         .. rubric:: Example
 
-        >>> from rt_eqcorrscan.streaming import RealTimeClient
+        >>> from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
         >>> rt_client = RealTimeClient(server_url="geofon.gfz-potsdam.de")
         >>> tribe = RealTimeTribe(
         ...     tribe=Tribe([Template(name='a', process_length=60)]),

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -427,6 +427,7 @@ class RealTimeTribe(Tribe):
                     len(self.detections)))
                 self._running = False  # Release lock
                 # See if there are templates to be added and run.
+                # TODO: This should run more frequently
                 self._add_templates_from_disk(
                     threshold=threshold, threshold_type=threshold_type,
                     trig_int=trig_int, keep_detections=keep_detections,
@@ -481,9 +482,14 @@ class RealTimeTribe(Tribe):
         endtime: UTCDateTime = None,
         **kwargs
     ):
+        Logger.info(f"Checking for events in {self._tribe_file}")
         if not os.path.isfile(self._tribe_file):
             return
         new_tribe = Tribe().read(self._tribe_file)
+        if len(new_tribe) == 0:
+            return
+        Logger.info(
+            f"Adding {len(new_tribe)} templates to already running tribe.")
         self.add_templates(
             new_tribe, threshold=threshold, threshold_type=threshold_type,
             trig_int=trig_int, keep_detections=keep_detections,

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -20,7 +20,6 @@ from typing import Union, List
 
 from obspy import Stream, UTCDateTime, Inventory
 from matplotlib.figure import Figure
-from multiprocessing import Process
 from eqcorrscan import Tribe, Template, Party, Detection
 
 from rt_eqcorrscan.streaming.streaming import _StreamingClient
@@ -564,6 +563,7 @@ class RealTimeTribe(Tribe):
         st = self.rt_client.wavebank.get_waveforms_bulk(bulk)
         Logger.debug("Additional templates to be run: \n{0} "
                      "templates".format(len(templates)))
+        # TODO: This could be in a non-blocking Process of it's own
         new_party = templates.detect(
             stream=st, plot=False, threshold=threshold,
             threshold_type=threshold_type, trig_int=trig_int,

--- a/rt_eqcorrscan/streaming/__init__.py
+++ b/rt_eqcorrscan/streaming/__init__.py
@@ -7,5 +7,4 @@ License
     GPL v3.0
 """
 
-from .seedlink import RealTimeClient
 from .buffers import Buffer

--- a/rt_eqcorrscan/streaming/clients/__init__.py
+++ b/rt_eqcorrscan/streaming/clients/__init__.py
@@ -1,0 +1,8 @@
+"""
+Streaming clients for RT_EQcorrscan
+
+Author
+    Calum J Chamberlain
+License
+    GPL v3.0
+"""

--- a/rt_eqcorrscan/streaming/clients/obsplus.py
+++ b/rt_eqcorrscan/streaming/clients/obsplus.py
@@ -1,0 +1,72 @@
+"""
+Data handling to simulate a real-time client from old data via ObsPlus WaveBank
+for testing of real-time matched-filter detection.
+
+Author
+    Calum J Chamberlain
+License
+    GPL v3.0
+"""
+import logging
+
+from obspy import Stream, UTCDateTime
+
+from obsplus import WaveBank
+
+from rt_eqcorrscan.database.client_emulation import ClientBank
+from rt_eqcorrscan.streaming.clients.obspy import RealTimeClient as OBSRTCli
+
+
+Logger = logging.getLogger(__name__)
+
+
+class RealTimeClient(OBSRTCli):
+    """
+    Simulation of a real-time client for past data. Used for testing
+
+    Parameters
+    ----------
+    server_url
+        The base-path for the ObsPlus wavebank.
+    client
+        Any client or that supports waveform data queries.
+    starttime
+        Starttime for client (in the past)
+    query_interval
+        Interval in seconds to query the client for new data
+    speed_up
+        Multiplier to run faster than real-time (real-time is 1.0).
+    buffer
+        Stream to buffer data into
+    buffer_capacity
+        Length of buffer in seconds. Old data are removed in a FIFO style.
+    """
+    def __init__(
+        self,
+        server_url: str,
+        starttime: UTCDateTime,
+        client=None,
+        query_interval: float = 10.,
+        speed_up: float = 1.,
+        buffer: Stream = None,
+        buffer_capacity: float = 600.,
+        **kwargs
+    ) -> None:
+        if client is None:
+            try:
+                wavebank = WaveBank(server_url)
+                client = ClientBank(wave_bank=wavebank)
+            except Exception as e:
+                Logger.error("Could not instantiate simulated client")
+                raise e
+        super().__init__(
+            server_url=server_url, starttime=starttime, client=client,
+            query_interval=query_interval, speed_up=speed_up, buffer=buffer,
+            buffer_capacity=buffer_capacity, wavebank=wavebank)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    logging.basicConfig(level="DEBUG")
+    doctest.testmod()

--- a/rt_eqcorrscan/streaming/clients/obsplus.py
+++ b/rt_eqcorrscan/streaming/clients/obsplus.py
@@ -54,15 +54,14 @@ class RealTimeClient(OBSRTCli):
     ) -> None:
         if client is None:
             try:
-                wavebank = WaveBank(server_url)
-                client = ClientBank(wave_bank=wavebank)
+                client = ClientBank(wave_bank=WaveBank(server_url))
             except Exception as e:
                 Logger.error("Could not instantiate simulated client")
                 raise e
         super().__init__(
             server_url=server_url, starttime=starttime, client=client,
             query_interval=query_interval, speed_up=speed_up, buffer=buffer,
-            buffer_capacity=buffer_capacity, wavebank=wavebank)
+            buffer_capacity=buffer_capacity, wavebank=None)
 
 
 if __name__ == "__main__":

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -1,5 +1,5 @@
 """
-Data handling to simulate a real-time client from old data via FDSN
+Data handling to simulate a real-time client from old data via ObsPy clients
 for testing of real-time matched-filter detection.
 
 Author
@@ -11,8 +11,9 @@ import logging
 import time
 import copy
 from numpy import random
+import importlib
 
-from obspy import Stream, UTCDateTime, clients
+from obspy import Stream, UTCDateTime
 
 from obsplus import WaveBank
 
@@ -46,6 +47,8 @@ class RealTimeClient(_StreamingClient):
     buffer_capacity
         Length of buffer in seconds. Old data are removed in a FIFO style.
     """
+    client_base = "obspy.clients"
+
     def __init__(
         self,
         server_url: str,
@@ -60,7 +63,8 @@ class RealTimeClient(_StreamingClient):
     ) -> None:
         if client is None:
             try:
-                _client_module = clients.__getattribute__(client_type.lower())
+                _client_module = importlib.import_module(
+                    f"{self.client_base}.{client_type.lower()}")
                 client = _client_module.Client(server_url)
             except Exception as e:
                 Logger.error("Could not instantiate simulated client")

--- a/rt_eqcorrscan/streaming/clients/seedlink.py
+++ b/rt_eqcorrscan/streaming/clients/seedlink.py
@@ -42,7 +42,7 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         EasySeedLinkClient.__init__(
             self, server_url=server_url, autoconnect=False)
         _StreamingClient.__init__(
-            self, client_name=server_url, buffer=buffer,
+            self, server_url=server_url, buffer=buffer,
             buffer_capacity=buffer_capacity, wavebank=wavebank)
         Logger.debug("Instantiated RealTime client: {0}".format(self))
 

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -35,8 +35,8 @@ class _StreamingClient(ABC):
     buffer_capacity
         Length of buffer in seconds. Old data are removed in a FIFO style.
     wavebank
-        Optional wavebank to save data to. Used for backfilling by
-        RealTimeTribe
+        WaveBank to save data to. Used for backfilling by RealTimeTribe.
+        Set to `None` to not use a WaveBank.
 
     Notes
     -----
@@ -52,7 +52,7 @@ class _StreamingClient(ABC):
         server_url: str = None,
         buffer: Union[Stream, Buffer] = None,
         buffer_capacity: float = 600.,
-        wavebank: WaveBank = None,
+        wavebank: WaveBank = WaveBank("Streaming_WaveBank"),
     ) -> None:
         self.server_url = server_url
         if buffer is None:
@@ -61,6 +61,7 @@ class _StreamingClient(ABC):
             buffer = Buffer(buffer.traces, maxlen=buffer_capacity)
         self._buffer = buffer
         self.buffer_capacity = buffer_capacity
+
         self.wavebank = wavebank
         self.threads = []
 
@@ -161,6 +162,9 @@ class _StreamingClient(ABC):
         self.buffer.add_stream(trace)
         if self.wavebank is not None:
             self.wavebank.put_waveforms(stream=Stream([trace]))
+            # Note that this should be undertaken by put_waveforms,
+            # but seems to get missed...
+            self.wavebank.update_index()
         Logger.debug("Buffer contains {0}".format(self.buffer))
 
     def on_terminate(self) -> Stream:  # pragma: no cover

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -49,12 +49,12 @@ class _StreamingClient(ABC):
 
     def __init__(
         self,
-        client_name: str = None,
+        server_url: str = None,
         buffer: Union[Stream, Buffer] = None,
         buffer_capacity: float = 600.,
         wavebank: WaveBank = None,
     ) -> None:
-        self.client_name = client_name
+        self.server_url = server_url
         if buffer is None:
             buffer = Buffer(traces=[], maxlen=buffer_capacity)
         elif isinstance(buffer, Stream):
@@ -72,7 +72,7 @@ class _StreamingClient(ABC):
         print_str = (
             "Client at {0}, status: {1}, buffer capacity: {2:.1f}s\n"
             "\tCurrent Buffer:\n{3}".format(
-                self.client_name, status_map[self.busy],
+                self.server_url, status_map[self.busy],
                 self.buffer_capacity, self.buffer))
         return print_str
 
@@ -170,7 +170,8 @@ class _StreamingClient(ABC):
         Logger.info("Termination of {0}".format(self.__repr__()))
         return self.buffer
 
-    def on_error(self):  # pragma: no cover
+    @staticmethod
+    def on_error():  # pragma: no cover
         """
         Handle errors gracefully.
         """

--- a/scripts/rteqcorrscan-build-db
+++ b/scripts/rteqcorrscan-build-db
@@ -42,7 +42,7 @@ def run(
 
     template_bank = TemplateBank(
         config.database_manager.event_path,
-        event_name_structure=config.database_manager.event_name_structure,
+        name_structure=config.database_manager.name_structure,
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
         event_ext=config.database_manager.event_ext,

--- a/scripts/rteqcorrscan-config
+++ b/scripts/rteqcorrscan-config
@@ -14,6 +14,7 @@ from rt_eqcorrscan.config import Config
 def run(outfile):
     config = Config()
     config.write(outfile)
+    print(f"Written config file: {outfile}")
 
 
 if __name__ == "__main__":

--- a/scripts/rteqcorrscan-reactor
+++ b/scripts/rteqcorrscan-reactor
@@ -71,14 +71,7 @@ def run(**kwargs):
     reactor = Reactor(
         client=client, rt_client=rt_client,
         listener=listener, trigger_func=trigger_func,
-        template_database=template_bank,
-        template_lookup_kwargs=dict(
-            starttime=config.database_manager.lookup_starttime),
-        real_time_tribe_kwargs=config.rt_match_filter,
-        plot_kwargs=config.plot,
-        listener_kwargs=dict(
-            min_stations=config.database_manager.min_stations,
-            template_kwargs=config.template))
+        template_database=template_bank, config=config)
     reactor.run()
     return
 

--- a/scripts/rteqcorrscan-reactor
+++ b/scripts/rteqcorrscan-reactor
@@ -50,7 +50,7 @@ def run(**kwargs):
 
     template_bank = TemplateBank(
         config.database_manager.event_path,
-        event_name_structure=config.database_manager.event_name_structure,
+        name_structure=config.database_manager.name_structure,
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
         event_ext=config.database_manager.event_ext,

--- a/scripts/rteqcorrscan-reactor
+++ b/scripts/rteqcorrscan-reactor
@@ -22,7 +22,6 @@ from rt_eqcorrscan.event_trigger import (
     magnitude_rate_trigger_func, CatalogListener)
 from rt_eqcorrscan.reactor import Reactor
 from rt_eqcorrscan.database import TemplateBank
-from rt_eqcorrscan.streaming import RealTimeClient
 
 
 Logger = logging.getLogger(__name__)
@@ -64,12 +63,9 @@ def run(**kwargs):
         template_bank=template_bank, interval=600, keep=86400.,
         catalog=Catalog(),
         waveform_client=config.rt_match_filter.get_waveform_client())
-    rt_client = RealTimeClient(
-        server_url=config.rt_match_filter.seedlink_server_url,
-        buffer_capacity=config.rt_match_filter.buffer_capacity)
 
     reactor = Reactor(
-        client=client, rt_client=rt_client,
+        client=client,
         listener=listener, trigger_func=trigger_func,
         template_database=template_bank, config=config)
     reactor.run()

--- a/scripts/rteqcorrscan-reactor
+++ b/scripts/rteqcorrscan-reactor
@@ -15,6 +15,8 @@ import faulthandler
 faulthandler.enable()
 
 from functools import partial
+from concurrent.futures import ProcessPoolExecutor
+
 from obspy import Catalog
 
 from rt_eqcorrscan.config import read_config
@@ -51,7 +53,8 @@ def run(**kwargs):
         event_name_structure=config.database_manager.event_name_structure,
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
-        event_ext=config.database_manager.event_ext)
+        event_ext=config.database_manager.event_ext,
+        executor=ProcessPoolExecutor())
 
     if update_bank:
         Logger.info("Updating bank before running")

--- a/scripts/rteqcorrscan-real-time-match
+++ b/scripts/rteqcorrscan-real-time-match
@@ -108,25 +108,17 @@ def run_real_time_matched_filter(**kwargs):
     for t in tribe:
         t.process_length = config.rt_match_filter.buffer_capacity
 
-    if rt_client_starttime is None:
-        speed_up = 1.0
-        rt_client = RealTimeClient(
-            server_url=config.rt_match_filter.seedlink_server_url,
-            buffer_capacity=config.rt_match_filter.buffer_capacity)
-    else:
-        speed_up = kwargs.get("speed_up", 1.0)
+    if rt_client_starttime is not None:
+        config.streaming.starttime = rt_client_starttime
+        config.streaming.speed_up = kwargs.get("speed_up", 1.0)
         config.plot.offline = True
-        rt_client = SimulateRealTimeClient(
-            server_url="Unreal-client", client=client,
-            starttime=rt_client_starttime,
-            buffer_capacity=config.rt_match_filter.buffer_capacity,
-            speed_up=speed_up)
+    rt_client = config.streaming.get_streaming_client()
     real_time_tribe = RealTimeTribe(
         tribe=tribe, inventory=inventory, rt_client=rt_client,
         detect_interval=config.rt_match_filter.detect_interval,
         plot=config.rt_match_filter.plot, name=tribe_name,
         plot_options=config.plot)
-    real_time_tribe._speed_up = speed_up
+    real_time_tribe._speed_up = config.streaming.speed_up
 
     party = None
     try:

--- a/scripts/rteqcorrscan-real-time-match
+++ b/scripts/rteqcorrscan-real-time-match
@@ -19,8 +19,8 @@ from rt_eqcorrscan.reactor import estimate_region, get_inventory
 from rt_eqcorrscan.database import TemplateBank, check_tribe_quality
 from rt_eqcorrscan.database.client_emulation import ClientBank
 from rt_eqcorrscan.rt_match_filter import RealTimeTribe
-from rt_eqcorrscan.streaming import RealTimeClient
-from rt_eqcorrscan.streaming.simulate import SimulateRealTimeClient
+from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
+from rt_eqcorrscan.streaming.clients.simulate import RealTimeClient as SimulateRealTimeClient
 
 
 Logger = logging.getLogger("real-time-mf")
@@ -117,7 +117,8 @@ def run_real_time_matched_filter(**kwargs):
         speed_up = kwargs.get("speed_up", 1.0)
         config.plot.offline = True
         rt_client = SimulateRealTimeClient(
-            client=client, starttime=rt_client_starttime,
+            server_url="Unreal-client", client=client,
+            starttime=rt_client_starttime,
             buffer_capacity=config.rt_match_filter.buffer_capacity,
             speed_up=speed_up)
     real_time_tribe = RealTimeTribe(

--- a/scripts/rteqcorrscan-real-time-match
+++ b/scripts/rteqcorrscan-real-time-match
@@ -19,8 +19,6 @@ from rt_eqcorrscan.reactor import estimate_region, get_inventory
 from rt_eqcorrscan.database import TemplateBank, check_tribe_quality
 from rt_eqcorrscan.database.client_emulation import ClientBank
 from rt_eqcorrscan.rt_match_filter import RealTimeTribe
-from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
-from rt_eqcorrscan.streaming.clients.simulate import RealTimeClient as SimulateRealTimeClient
 
 
 Logger = logging.getLogger("real-time-mf")
@@ -71,7 +69,7 @@ def run_real_time_matched_filter(**kwargs):
         region.update({"endtime": rt_client_starttime})
     bank = TemplateBank(
         base_path=config.database_manager.event_path,
-        event_name_structure=config.database_manager.event_name_structure,
+        name_structure=config.database_manager.name_structure,
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
         event_ext=config.database_manager.event_ext)

--- a/scripts/rteqcorrscan-simulation
+++ b/scripts/rteqcorrscan-simulation
@@ -21,7 +21,7 @@ from concurrent.futures import ProcessPoolExecutor
 
 from rt_eqcorrscan import TemplateBank, RealTimeTribe
 from rt_eqcorrscan.config.config import TemplateConfig, PlotConfig
-from rt_eqcorrscan.reactor.reactor import get_inventory
+from rt_eqcorrscan.reactor.spin_up import get_inventory
 from rt_eqcorrscan.streaming.simulate import SimulateRealTimeClient
 from rt_eqcorrscan.database.database_manager import check_tribe_quality
 from rt_eqcorrscan.database.client_emulation import ClientBank
@@ -58,7 +58,7 @@ def synthesise_real_time(
 ):
     """
     """
-    bank = TemplateBank(database_path) #, executor=ProcessPoolExecutor())
+    bank = TemplateBank(database_path, executor=ProcessPoolExecutor())
     full_template_kwargs = TemplateConfig().__dict__
     full_template_kwargs.update(template_kwargs)
 
@@ -108,9 +108,9 @@ def synthesise_real_time(
                         endtime=detection_starttime + detection_runtime)
                 except Exception as e:
                     Logger.error(
-                        f"Could not download data for "
-                         "{network.code}.{station.code}."
-                         "{channel.location_code}.{channel.code}")
+                        "Could not download data for "
+                        f"{network.code}.{station.code}."
+                        f"{channel.location_code}.{channel.code}")
                     Logger.error(e)
                     continue
                 wavebank.put_waveforms(st)
@@ -128,6 +128,7 @@ def synthesise_real_time(
         plot_options=full_plot_kwargs,
         name=triggering_event.resource_id.id.split('/')[-1])
 
+    # TODO: Use the subprocess methods in Reactor - simulate a reactor...
     rt_tribe.background_run(
         threshold=threshold, threshold_type=threshold_type, trig_int=trig_int)
     
@@ -178,7 +179,6 @@ def synthesise_real_time(
         last_query_time = run_time
         run_time = run_time + (query_interval / speed_up)
     rt_tribe.stop()
-
 
 
 if __name__ == "__main__":

--- a/scripts/rteqcorrscan-simulation
+++ b/scripts/rteqcorrscan-simulation
@@ -44,7 +44,7 @@ def synthesise_real_time(
     make_templates: bool = True,
     speed_up: float = 1,
     debug: bool = False,
-    query_interval: float = 600,
+    query_interval: float = 60,
 ):
     """
     """
@@ -68,7 +68,7 @@ def synthesise_real_time(
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
         event_ext=config.database_manager.event_ext,
-        executor=ProcessPoolExecutor())
+        executor=None)
 
     if make_templates:
         Logger.info("Downloading template events")
@@ -97,7 +97,7 @@ def synthesise_real_time(
     config.plot.update({"offline": True})  # Use to use data time-stamps
 
     Logger.info("Downloading data")
-    wavebank = WaveBank(f"{config.database_manager.event_path}_wave")
+    wavebank = WaveBank("simulation_wavebank")
     for network in inventory:
         for station in network:
             for channel in station:

--- a/scripts/rteqcorrscan-simulation
+++ b/scripts/rteqcorrscan-simulation
@@ -64,7 +64,7 @@ def synthesise_real_time(
 
     template_bank = TemplateBank(
         config.database_manager.event_path,
-        event_name_structure=config.database_manager.event_name_structure,
+        name_structure=config.database_manager.name_structure,
         event_format=config.database_manager.event_format,
         path_structure=config.database_manager.path_structure,
         event_ext=config.database_manager.event_ext,

--- a/scripts/rteqcorrscan-simulation
+++ b/scripts/rteqcorrscan-simulation
@@ -8,27 +8,28 @@ This script has 3 main steps:
     3. Start the RealTimeTribe
 """
 import logging
-import time
 
 from obspy import UTCDateTime
-from obspy.core.event import Event
 from obspy.clients.fdsn import Client
 
 from obsplus import WaveBank
 
 from collections import namedtuple
 from concurrent.futures import ProcessPoolExecutor
+from functools import partial
 
-from rt_eqcorrscan import TemplateBank, RealTimeTribe
-from rt_eqcorrscan.config.config import TemplateConfig, PlotConfig
+from rt_eqcorrscan import TemplateBank, Reactor, read_config
 from rt_eqcorrscan.reactor.spin_up import get_inventory
-from rt_eqcorrscan.streaming.clients.simulate import RealTimeClient
-from rt_eqcorrscan.database.database_manager import check_tribe_quality
-from rt_eqcorrscan.database.client_emulation import ClientBank
+from rt_eqcorrscan.config.config import Config
+from rt_eqcorrscan.event_trigger import (
+    CatalogListener, magnitude_rate_trigger_func)
 
 Logger = logging.getLogger(__name__)
 
-DATABASE_BASE = "/home/chambeca/Desktop/Temporary_databases"
+KNOWN_QUAKES = {
+    "eketahuna": "2014p051675",
+    "cook-strait": "2013p543824",  # M 6.5 preceeded by two 5.7 and 5.8
+}
 
 Region = namedtuple("Region", ["latitude", "longitude", "radius"])
 
@@ -38,32 +39,36 @@ def synthesise_real_time(
     database_endtime: UTCDateTime,
     database_region: Region,
     detection_starttime: UTCDateTime,
-    client: Client,
-    triggering_event: Event,
-    database_path: str,
+    config: Config,
     detection_runtime: float = 3600.0,
-    template_kwargs: dict = None,
-    plot_kwargs: dict = None,
-    max_station_distance: float = 200.0,
-    n_stations: int = 10,
-    detect_interval: float = 10,
-    plot: bool = True,
-    threshold: float = 10.0,
-    threshold_type: str = "MAD",
-    trig_int: float = 2.0,
-    min_stations: int = 5,
     make_templates: bool = True,
-    query_interval: float = 30,
     speed_up: float = 1,
+    debug: bool = False,
+    query_interval: float = 600,
 ):
     """
     """
-    template_kwargs = template_kwargs or dict()
-    plot_kwargs = plot_kwargs or dict()
+    if debug:
+        config.log_level = "DEBUG"
+        print("Using the following configuration:\n{0}".format(config))
+    config.setup_logging()
 
-    bank = TemplateBank(database_path, executor=ProcessPoolExecutor())
-    full_template_kwargs = TemplateConfig().__dict__
-    full_template_kwargs.update(template_kwargs)
+    client = config.rt_match_filter.get_client()
+
+    trigger_func = partial(
+        magnitude_rate_trigger_func,
+        magnitude_threshold=config.reactor.magnitude_threshold,
+        rate_threshold=config.reactor.rate_threshold,
+        rate_bin=config.reactor.rate_radius,
+        minimum_events_in_bin=config.reactor.minimum_events_in_bin)
+
+    template_bank = TemplateBank(
+        config.database_manager.event_path,
+        event_name_structure=config.database_manager.event_name_structure,
+        event_format=config.database_manager.event_format,
+        path_structure=config.database_manager.path_structure,
+        event_ext=config.database_manager.event_ext,
+        executor=ProcessPoolExecutor())
 
     if make_templates:
         Logger.info("Downloading template events")
@@ -74,30 +79,25 @@ def synthesise_real_time(
             maxradius=database_region.radius)
         
         Logger.info("Building template database")
-        tribe = bank.make_templates(
-            catalog=catalog, client=client, **full_template_kwargs)
-    else:
-        tribe = bank.get_templates(
-            starttime=database_starttime, endtime=database_endtime,
-            latitude=database_region.latitude, 
-            longitude=database_region.longitude,
-            maxradius=database_region.radius)
-    
-    Logger.info("Removing dodgy templates")
-    tribe = check_tribe_quality(
-        tribe, min_stations=min_stations, **full_template_kwargs)
-    
+        template_bank.make_templates(
+            catalog=catalog, client=client, **config.template)
+    tribe = template_bank.get_templates(
+        starttime=database_starttime, endtime=database_endtime,
+        latitude=database_region.latitude,
+        longitude=database_region.longitude,
+        maxradius=database_region.radius)
     inventory = get_inventory(
-        client, tribe, triggering_event=triggering_event,
-        max_distance=max_station_distance,
-        n_stations=n_stations)
+        client=client, tribe=tribe, starttime=detection_starttime,
+        location={"latitude": database_region.latitude,
+                  "longitude": database_region.longitude},
+        duration=detection_runtime / 86400.,
+        max_distance=config.rt_match_filter.max_distance,
+        n_stations=config.rt_match_filter.n_stations)
 
-    full_plot_kwargs = PlotConfig().__dict__
-    full_plot_kwargs.update(plot_kwargs)
-    full_plot_kwargs.update({"offline": True}) # Use to use data time-stamps
+    config.plot.update({"offline": True})  # Use to use data time-stamps
 
     Logger.info("Downloading data")
-    wavebank = WaveBank(f"{database_path}_wave")
+    wavebank = WaveBank(f"{config.database_manager.event_path}_wave")
     for network in inventory:
         for station in network:
             for channel in station:
@@ -117,90 +117,44 @@ def synthesise_real_time(
                     Logger.error(e)
                     continue
                 wavebank.put_waveforms(st)
-    client_bank = ClientBank(
-        wave_bank=wavebank, event_bank=client, station_bank=client)
 
-    rt_client = RealTimeClient(
-        server_url="Unreal-streamer", client=client_bank, query_interval=1,
-        starttime=detection_starttime, speed_up=speed_up)
-    
-    Logger.info("Starting detection")
-    rt_tribe = RealTimeTribe(
-        tribe=tribe, inventory=inventory, rt_client=rt_client,
-        detect_interval=detect_interval, plot=plot,
-        plot_options=full_plot_kwargs,
-        name=triggering_event.resource_id.id.split('/')[-1])
+    # Set up config to use the wavebank rather than FDSN.
+    config.streaming.update(
+        {"rt_client_url": str(wavebank.bank_path),
+         "rt_client_type": "obsplus",
+         "starttime": detection_starttime,
+         "speed_up": speed_up,
+         "query_interval": 1.0})
 
-    # TODO: Use the subprocess methods in Reactor - simulate a reactor...
-    rt_tribe.background_run(
-        threshold=threshold, threshold_type=threshold_type, trig_int=trig_int)
-    
-    # TODO: Streamline these variables - lots of crap flying around!
-    last_query_time = detection_starttime
-    run_time = detection_starttime + query_interval
-    detection_endtime = detection_starttime + detection_runtime
-    time.sleep(query_interval / speed_up)
-    while run_time < detection_endtime:
-        _loop_starttime = UTCDateTime.now()
-        Logger.debug(
-            f"Checking for events between {last_query_time} and {run_time}")
-        try:
-            new_catalog = client.get_events(
-                starttime=last_query_time, endtime=run_time,
-                latitude=database_region.latitude, 
-                longitude=database_region.longitude,
-                maxradius=database_region.radius)
-        except Exception:
-            time.sleep(query_interval / speed_up)
-            run_time += query_interval
-            continue
-        if len(new_catalog) == 0:
-            time.sleep(query_interval / speed_up)
-            run_time += query_interval
-            continue
-        Logger.info("Adding {0} new templates to database".format(
-            len(new_catalog)))
-        new_tribe = bank.make_templates(
-            catalog=new_catalog, client=client, **full_template_kwargs)
-        rt_tribe.add_templates(
-            new_tribe, threshold=threshold, threshold_type=threshold_type, 
-            trig_int=trig_int)
-        Logger.info(f"Tribe is now at {rt_tribe}")
-        _loop_endtime = UTCDateTime.now()
-        _loop_duration = (_loop_endtime - _loop_starttime) * speed_up
-        Logger.debug(f"Template loop took {_loop_duration}s")
+    catalog_lookup_kwargs = database_region._asdict()
+    radius = catalog_lookup_kwargs.pop("radius")
+    catalog_lookup_kwargs.update({"maxradius": radius})
+    listener = CatalogListener(
+        client=client, catalog_lookup_kwargs=catalog_lookup_kwargs,
+        template_bank=template_bank, interval=query_interval, keep=86400,
+        catalog=None, waveform_client=client)
+    listener._speed_up = speed_up
+    listener._test_start_step = UTCDateTime.now() - detection_starttime
 
-        sleep_step = (query_interval / speed_up) - _loop_duration
-        if sleep_step > 0:
-            Logger.debug(f"Sleeping for {sleep_step}s")
-            time.sleep(sleep_step)
-        else:
-            Logger.debug(
-                "Loop took longer than query-interval, setting query "
-                f"interval to {_loop_duration}")
-            query_interval = _loop_duration
-        last_query_time = run_time
-        run_time = run_time + (query_interval / speed_up)
-    rt_tribe.stop()
+    reactor = Reactor(
+        client=client,
+        listener=listener, trigger_func=trigger_func,
+        template_database=template_bank, config=config)
+    Logger.info("Starting reactor")
+    reactor.run()
 
 
 if __name__ == "__main__":
-    import os
     import argparse
-
-    logging.basicConfig(
-        level="INFO",
-        format="%(asctime)s\t[%(processName)s:%(threadName)s]: %(name)s\t%(levelname)s\t%(message)s")
-
-    KNOWN_QUAKES = {
-        "eketahuna": "2014p051675",
-        "cook-strait": "2013p543824",  # M 6.5 preceeded by two 5.7 and 5.8
-    }
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--quake", type=str, 
-        help="Earthquake to synthesise real-time, either the event-id or a known key")
+        "--quake", type=str, required=True,
+        help="Earthquake to synthesise real-time, either the event-id or a "
+             f"known key.\n Known events are: \n{KNOWN_QUAKES}")
+    parser.add_argument(
+        "--config", "-c", type=str, default=None,
+        help="Path to configuration file", required=False)
     parser.add_argument(
         "--db-duration", type=int, default=365,
         help="Number of days to generate the database for prior to the chosen event")
@@ -208,11 +162,14 @@ if __name__ == "__main__":
         "--radius", type=float, default=0.5,
         help="Radius in degrees to build database for")
     parser.add_argument(
-        "--client", type=str, default="GEONET",
+        "--client", type=str, required=True,
         help="Client to get data from, must have an FDSN waveform and event service")
     parser.add_argument(
         "--templates-made", action="store_false",
         help="Flag to not make new templates - use if re-running an old DB")
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Flag to run in debug mode, with lots of output to screen")
     
     args = parser.parse_args()
 
@@ -222,6 +179,7 @@ if __name__ == "__main__":
         Logger.warning(e)
         client = Client(args.client)
 
+    config = read_config(args.config)
     quake_id = KNOWN_QUAKES.get(args.quake, args.quake)
     trigger_event = client.get_events(eventid=quake_id)[0]
     trigger_origin = trigger_event.preferred_origin() or trigger_event.origins[0]
@@ -234,6 +192,5 @@ if __name__ == "__main__":
         database_endtime=trigger_origin.time,
         database_starttime=trigger_origin.time - (args.db_duration * 86400),
         database_region=region, detection_starttime=trigger_origin.time,
-        client=client, triggering_event=trigger_event,
-        database_path=os.path.join(DATABASE_BASE, quake_id),
-        make_templates=args.templates_made)
+        config=config, make_templates=args.templates_made,
+        debug=args.debug)

--- a/scripts/rteqcorrscan-simulation
+++ b/scripts/rteqcorrscan-simulation
@@ -22,7 +22,7 @@ from concurrent.futures import ProcessPoolExecutor
 from rt_eqcorrscan import TemplateBank, RealTimeTribe
 from rt_eqcorrscan.config.config import TemplateConfig, PlotConfig
 from rt_eqcorrscan.reactor.spin_up import get_inventory
-from rt_eqcorrscan.streaming.simulate import SimulateRealTimeClient
+from rt_eqcorrscan.streaming.clients.simulate import RealTimeClient
 from rt_eqcorrscan.database.database_manager import check_tribe_quality
 from rt_eqcorrscan.database.client_emulation import ClientBank
 
@@ -42,8 +42,8 @@ def synthesise_real_time(
     triggering_event: Event,
     database_path: str,
     detection_runtime: float = 3600.0,
-    template_kwargs: dict = dict(),
-    plot_kwargs: dict = dict(),
+    template_kwargs: dict = None,
+    plot_kwargs: dict = None,
     max_station_distance: float = 200.0,
     n_stations: int = 10,
     detect_interval: float = 10,
@@ -58,6 +58,9 @@ def synthesise_real_time(
 ):
     """
     """
+    template_kwargs = template_kwargs or dict()
+    plot_kwargs = plot_kwargs or dict()
+
     bank = TemplateBank(database_path, executor=ProcessPoolExecutor())
     full_template_kwargs = TemplateConfig().__dict__
     full_template_kwargs.update(template_kwargs)
@@ -117,8 +120,8 @@ def synthesise_real_time(
     client_bank = ClientBank(
         wave_bank=wavebank, event_bank=client, station_bank=client)
 
-    rt_client = SimulateRealTimeClient(
-        client=client_bank, query_interval=1,
+    rt_client = RealTimeClient(
+        server_url="Unreal-streamer", client=client_bank, query_interval=1,
         starttime=detection_starttime, speed_up=speed_up)
     
     Logger.info("Starting detection")

--- a/tests/config_tests/config_test.py
+++ b/tests/config_tests/config_test.py
@@ -21,7 +21,7 @@ class TestConfig(unittest.TestCase):
         # Check that we can get attributes
         self.assertIsInstance(config.rt_match_filter.n_stations, int)
         self.assertIsInstance(config.rt_match_filter.plot, bool)
-        self.assertIsInstance(config.rt_match_filter.seedlink_server_url, str)
+        self.assertIsInstance(config.rt_match_filter.rt_client_url, str)
         client = config.rt_match_filter.get_client()
         self.assertTrue(hasattr(client, "get_events"))
 
@@ -81,6 +81,12 @@ class TestConfig(unittest.TestCase):
         config.rt_match_filter.waveform_client = "GEONET"
         client = config.rt_match_filter.get_waveform_client()
         self.assertIsInstance(client, Client)
+
+    def test_get_streaming_client(self):
+        config = Config()
+        rt_client = config.rt_match_filter.get_streaming_client()
+        self.assertEqual(
+            rt_client.server_url, config.rt_match_filter.rt_client_url)
 
     def test_bad_init(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/config_tests/default_config.yml
+++ b/tests/config_tests/default_config.yml
@@ -6,7 +6,8 @@ reactor:
 rt match filter:
   client: "GEONET"
   client type: "FDSN"
-  seedlink server url: "link.geonet.org.nz"
+  rt client url: "link.geonet.org.nz"
+  rt client type: "seedlink"
   n stations: 10
   max distance: 1000
   buffer capacity: 300

--- a/tests/plotting_tests/plot_buffer_test.py
+++ b/tests/plotting_tests/plot_buffer_test.py
@@ -17,7 +17,7 @@ from obspy.clients.fdsn import Client
 
 from eqcorrscan.core.match_filter import Tribe, Detection, Template
 
-from rt_eqcorrscan.streaming.seedlink import RealTimeClient
+from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
 from rt_eqcorrscan.plotting.plot_buffer import EQcorrscanPlot
 
 

--- a/tests/real_time_test.py
+++ b/tests/real_time_test.py
@@ -13,7 +13,7 @@ from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
 
 from rt_eqcorrscan.rt_match_filter import RealTimeTribe
-from rt_eqcorrscan.streaming import RealTimeClient
+from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
 from rt_eqcorrscan.reactor import get_inventory
 
 

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -10,7 +10,7 @@ import numpy as np
 from obspy import Stream
 from obsplus import WaveBank
 
-from rt_eqcorrscan.streaming import RealTimeClient
+from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
 
 
 class SeedLinkTest(unittest.TestCase):

--- a/tests/streaming_tests/simulate_test.py
+++ b/tests/streaming_tests/simulate_test.py
@@ -8,7 +8,7 @@ import time
 from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
 
-from rt_eqcorrscan.streaming.clients.simulate import SimulateRealTimeClient
+from rt_eqcorrscan.streaming.clients.simulate import RealTimeClient
 
 SLEEP_STEP = 40
 
@@ -17,7 +17,8 @@ class FDSNTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = Client("GEONET")
-        cls.rt_client = SimulateRealTimeClient(
+        cls.rt_client = RealTimeClient(
+            server_url="Unreal-streamer",
             client=cls.client, buffer_capacity=10,
             starttime=UTCDateTime(2017, 1, 1), speed_up=4., query_interval=5.)
 

--- a/tests/streaming_tests/simulate_test.py
+++ b/tests/streaming_tests/simulate_test.py
@@ -5,10 +5,10 @@ Tests for simulating a real-time client.
 import unittest
 import time
 
-from obspy import Stream, UTCDateTime
+from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
 
-from rt_eqcorrscan.streaming.simulate import SimulateRealTimeClient
+from rt_eqcorrscan.streaming.clients.simulate import SimulateRealTimeClient
 
 SLEEP_STEP = 40
 


### PR DESCRIPTION
This PR changes detectors run by a `Reactor` to run as subprocesses rather than using multiprocessing.  No communication is required between the `Reactor` and the individual detectors, with the `Reactor` controlling which templates are run by which detector.

New templates are added by writing a new tribe file into the individual detector working directory. The detector checks for this file and reads from it and removes it once it is done. In this way templates can be added to a running detector, while it is running.

As an added advantage, this allows subprocessed detectors to write to their own log-file (which is what I wanted). This keeps logs seperate making it easier to understand what process is doing what. This closes #5 

The main reason for doing this was that memory would increase monotonically with the number of detectors running.  This was due to the use of `os.fork` under the hood when spawning new processes.  I tried using `os.spawn`, but ran into some other issues that I forget. `os.fork` replicates the memory for each new process.  This was not ideal.