### PR TITLE
Move Streamers from Threads to Processes

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -12,7 +12,7 @@ dependencies:
   - pyyaml
   - pyfftw>=0.12.0
   - pyproj>2.1
-  - EQcorrscan>=0.4.1
+  - EQcorrscan>=0.4.3
   - urllib3>=1.24.3
   - obsplus>=0.1.0
   - pytest>=2.0.0

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -11,7 +11,7 @@ dependencies:
   - h5py
   - pyyaml
   - pyfftw>=0.12.0
-  - pyproj<2
+  - pyproj>2.1
   - EQcorrscan>=0.4.1
   - urllib3>=1.24.3
   - obsplus>=0.1.0

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test -n 4 --dist=loadscope -v --cov-report=xml
+          py.test -v --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -42,17 +42,17 @@ jobs:
           conda info -a
           conda list
 
-#      - name: run test suite
-#        shell: bash -l {0}
-#        run: |
-#          export CI="true"
-#          py.test -v --cov-report=xml
-
-      - name: run streamer tests
+      - name: run test suite
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test tests/streaming_tests -v --cov-report=xml
+          py.test -n 2 --dist=loadscope --cov-report=xml
+
+#      - name: run streamer tests
+#        shell: bash -l {0}
+#        run: |
+#          export CI="true"
+#          py.test tests/streaming_tests -v --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test --dist=loadscope --cov-report=xml
+          py.test --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test -n 2 --dist=loadscope --cov-report=xml
+          py.test -n 1 --dist=loadscope -v --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test --cov-report=xml
+          py.test -n 2 --dist=loadscope --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test -n 1 --dist=loadscope -v --cov-report=xml
+          py.test -n 4 --dist=loadscope -v --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test -n 2 --dist=loadscope --cov-report=xml
+          py.test --dist=loadscope --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -42,11 +42,17 @@ jobs:
           conda info -a
           conda list
 
-      - name: run test suite
+#      - name: run test suite
+#        shell: bash -l {0}
+#        run: |
+#          export CI="true"
+#          py.test -v --cov-report=xml
+
+      - name: run streamer tests
         shell: bash -l {0}
         run: |
           export CI="true"
-          py.test -v --cov-report=xml
+          py.test tests/streaming_tests -v --cov-report=xml
 
       - name: upload coverage
         uses: codecov/codecov-action@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ obspy>=1.0.3
 h5py
 pyyaml
 pyfftw>=0.12.0
-pyproj<2
+pyproj>2.1
 codecov
 EQcorrscan>=0.4.2
 urllib3>=1.24.3

--- a/rt_eqcorrscan/config/config.py
+++ b/rt_eqcorrscan/config/config.py
@@ -136,12 +136,6 @@ class StreamingConfig(_ConfigAttribDict):
         super().__init__(*args, **kwargs)
 
     @property
-    def _local_wave_bank(self):
-        if isinstance(self.local_wave_bank, str):
-            return WaveBank(self.local_wave_bank)
-        return None
-
-    @property
     def rt_client_module(self):
         return importlib.import_module(
             f"{self.rt_client_base}.{self.rt_client_type.lower()}")

--- a/rt_eqcorrscan/config/config.py
+++ b/rt_eqcorrscan/config/config.py
@@ -71,6 +71,7 @@ class RTMatchFilterConfig(_ConfigAttribDict):
         "save_waveforms": True,
         "plot_detections": False,
         "max_correlation_cores": None,
+        "local_wave_bank": None,
     }
     readonly = []
 
@@ -126,7 +127,6 @@ class StreamingConfig(_ConfigAttribDict):
         "rt_client_url": "link.geonet.org.nz",
         "rt_client_type": "seedlink",
         "buffer_capacity": 300.,
-        "local_wave_bank": None,
     }
     readonly = []
     rt_client_base = "rt_eqcorrscan.streaming.clients"
@@ -167,7 +167,6 @@ class StreamingConfig(_ConfigAttribDict):
             rt_client = _client_module.RealTimeClient(
                 server_url=self.rt_client_url,
                 buffer_capacity=self.buffer_capacity,
-                wavebank=self._local_wave_bank,
                 **kwargs)
         except Exception as e:
             Logger.error(e)

--- a/rt_eqcorrscan/console_scripts/real_time_match.py
+++ b/rt_eqcorrscan/console_scripts/real_time_match.py
@@ -112,7 +112,8 @@ def run_real_time_matched_filter(**kwargs):
         tribe=tribe, inventory=inventory, rt_client=rt_client,
         detect_interval=config.rt_match_filter.detect_interval,
         plot=config.rt_match_filter.plot, name=tribe_name,
-        plot_options=config.plot)
+        plot_options=config.plot,
+        wavebank=config.rt_match_filter.local_wave_bank)
     try:
         real_time_tribe._speed_up = config.streaming.speed_up
     except AttributeError:

--- a/rt_eqcorrscan/event_trigger/catalog_listener.py
+++ b/rt_eqcorrscan/event_trigger/catalog_listener.py
@@ -310,8 +310,12 @@ class CatalogListener(_Listener):
                     else:
                         self.template_bank.put_events(new_events)
                     # Putting the events in the bank clears the catalog.
-                    self.extend(event_info)
-                    Logger.debug("Old events current state: {0}".format(
+                    Logger.info(f"Putting events into old_events: \n{event_info}")
+                    # Try looping... extend seems unstable?
+                    for ev_info in event_info:
+                        self.append(ev_info)
+                    # self.extend(event_info)
+                    Logger.info("Old events current state: {0}".format(
                         self.old_events))
             self.previous_time = now
             # Sleep in steps to make death responsive

--- a/rt_eqcorrscan/event_trigger/listener.py
+++ b/rt_eqcorrscan/event_trigger/listener.py
@@ -72,7 +72,7 @@ class _Listener(ABC):
         if len(self.old_events) == 0:
             return
         time_diffs = np.array([endtime - tup[1] for tup in self.old_events])
-        filt = time_diffs <= self.keep
+        filt = time_diffs >= self.keep
         # Need to remove in-place, without creating a new list
         for i, old_event in enumerate(list(self.old_events)):
             if not filt[i]:

--- a/rt_eqcorrscan/event_trigger/listener.py
+++ b/rt_eqcorrscan/event_trigger/listener.py
@@ -59,6 +59,11 @@ class _Listener(ABC):
         with self.lock:
             self._old_events.extend(events)
 
+    def append(self, other: EventInfo):
+        assert isinstance(other, EventInfo)
+        with self.lock:
+            self._old_events.append(other)
+
     def _remove_old_events(self, endtime: UTCDateTime) -> None:
         """
         Expire old events from the cache.
@@ -75,7 +80,8 @@ class _Listener(ABC):
         filt = time_diffs >= self.keep
         # Need to remove in-place, without creating a new list
         for i, old_event in enumerate(list(self.old_events)):
-            if not filt[i]:
+            if filt[i]:
+                Logger.info(f"Removing event {old_event} which is {time_diffs[i]} old, older than {self.keep}")
                 self.remove_old_event(old_event)
 
     def background_run(self, *args, **kwargs):

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -83,7 +83,8 @@ def run(working_dir: str, cores: int = 1, log_to_screen: bool = False):
         tribe=tribe, inventory=inventory, rt_client=rt_client,
         detect_interval=detect_interval, plot=plot,
         plot_options=config.plot,
-        name=triggering_event.resource_id.id.split('/')[-1])
+        name=triggering_event.resource_id.id.split('/')[-1],
+        wavebank=config.rt_match_filter.local_wave_bank)
     if real_time_tribe.expected_seed_ids is None:
         Logger.error("No matching channels in inventory and templates")
         return

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -41,8 +41,8 @@ def run(working_dir: str, cores: int = 1, log_to_screen: bool = False):
         filename="{0}/rt_eqcorrscan_{1}.log".format(
             working_dir,
             os.path.split(working_dir)[-1]))
-    # Enforce a local-wave-bank for the streamer
-    config.streaming.local_wave_bank = "streaming_wavebank"
+    # Enforce a local-wave-bank for the spun-up real-time instance
+    config.rt_match_filter.local_wave_bank = "streaming_wavebank"
 
     triggering_event = read_events('triggering_event.xml')[0]
     Logger.debug(f"Triggered by {triggering_event}")

--- a/rt_eqcorrscan/reactor/spin_up.py
+++ b/rt_eqcorrscan/reactor/spin_up.py
@@ -105,7 +105,7 @@ def run(working_dir: str, cores: int = 1, log_to_screen: bool = False):
     backfill_to = event_time(triggering_event) - 180
     backfill_client = config.rt_match_filter.get_waveform_client()
 
-    if backfill_client and rt_client.wavebank:
+    if backfill_client and real_time_tribe.wavebank:
         # Download the required data and write it to disk.
         endtime = UTCDateTime.now()
         Logger.info(
@@ -133,7 +133,7 @@ def run(working_dir: str, cores: int = 1, log_to_screen: bool = False):
             Logger.warning("No backfill available, skipping")
         else:
             st = st.split()  # Cannot write masked data
-            rt_client.wavebank.put_waveforms(st)
+            real_time_tribe.wavebank.put_waveforms(st)
         backfill_stations = {tr.stats.station for tr in st}
         backfill_templates = [
             t for t in real_time_tribe.templates

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -1237,9 +1237,11 @@ def _write_detection(
     if save_waveform:
         st = st.split()
         for tr in st:
+            # Ensure data are int32, see https://github.com/obspy/obspy/issues/2683
             if tr.data.dtype == numpy.int32 and \
               tr.data.dtype.type != numpy.int32:
-                # Ensure data are int32, see https://github.com/obspy/obspy/issues/2683
+                tr.data = tr.data.astype(numpy.int32)
+            if tr.data.dtype.type == numpy.intc:
                 tr.data = tr.data.astype(numpy.int32)
         st.write(f"{_filename}.ms", format="MSEED")
     return fig

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -941,7 +941,7 @@ class RealTimeTribe(Tribe):
         else:
             starttime = UTCDateTime(0)
         Logger.info(f"Backfilling between {starttime} and {endtime}")
-        if starttime >= endtime or not self.rt_client.has_wavebank:
+        if starttime >= endtime or not self.has_wavebank:
             return
         if self.expected_seed_ids and len(self.expected_seed_ids) > 0:
             bulk = []

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -15,6 +15,7 @@ import glob
 from typing import Union, List, Iterable
 
 from obspy import Stream, UTCDateTime, Inventory, Trace
+from obsplus import WaveBank
 from matplotlib.figure import Figure
 from multiprocessing import Process, Lock
 from eqcorrscan import Tribe, Template, Party, Detection
@@ -50,6 +51,9 @@ class RealTimeTribe(Tribe):
         Whether to generate the real-time bokeh plot
     plot_options
         Plotting options parsed to `rt_eqcorrscan.plotting.plot_buffer`
+    wavebank
+        WaveBank to save data to. Used for backfilling by RealTimeTribe.
+        Set to `None` to not use a WaveBank.
     
     sleep_step
         Default sleep-step in seconds while waiting for data. Defaults to 1.0
@@ -76,6 +80,10 @@ class RealTimeTribe(Tribe):
     _min_run_length = 24 * 3600  # Minimum run-length in seconds.
     # Usurped by max_run_length, used to set a threshold for rate calculation.
 
+    # WaveBank management
+    wavebank_lock = Lock()
+    has_wavebank = False
+
     def __init__(
         self,
         name: str = None,
@@ -85,6 +93,7 @@ class RealTimeTribe(Tribe):
         detect_interval: float = 60.,
         plot: bool = True,
         plot_options: dict = None,
+        wavebank: WaveBank = WaveBank("Streaming_WaveBank"),
     ) -> None:
         super().__init__(templates=tribe.templates)
         self.rt_client = rt_client
@@ -103,6 +112,12 @@ class RealTimeTribe(Tribe):
                 key: value for key, value in plot_options.items()
                 if key != "plot_length"})
         self.detections = []
+
+        # Wavebank status to avoid accessing the underlying, lockable, wavebank
+        self.__wavebank = wavebank
+        if wavebank:
+            self.has_wavebank = True
+        self._wavebank_warned = False  # Reduce duplicate warnings
 
     def __repr__(self):
         """
@@ -167,6 +182,18 @@ class RealTimeTribe(Tribe):
         """
         return {t.name for t in self.templates}
 
+    @property
+    def wavebank(self):
+        return self.__wavebank
+
+    @wavebank.setter
+    def wavebank(self, wavebank: WaveBank):
+        self.__wavebank = wavebank
+        if wavebank:
+            self.has_wavebank = True
+        else:
+            self.has_wavebank = False
+
     def _ensure_templates_have_enough_stations(self, min_stations):
         """ Remove templates that don't have enough stations. """
         self.templates = [
@@ -191,6 +218,67 @@ class RealTimeTribe(Tribe):
             else:
                 active_backfillers.append(backfill_process)
         self._backfillers = active_backfillers
+
+    def _access_wavebank(
+        self,
+        method: str,
+        timeout: float = None,
+        *args, **kwargs
+    ):
+        """
+        Thread and process safe access to the wavebank.
+
+        Multiple processes cannot access the underlying HDF5 file at the same
+        time.  This method waits until access to the HDF5 file is available and
+
+        Parameters
+        ----------
+        method
+            Method of wavebank to call
+        timeout
+            Maximum time to try to get access to the file
+        args
+            Arguments passed to method
+        kwargs
+            Keyword arguments passed to method
+
+        Returns
+        -------
+        Whatever should be returned by the method.
+        """
+        if not self.has_wavebank:
+            if not self._wavebank_warned:
+                Logger.error("No wavebank attached to streamer")
+            return None
+        timer, wait_step = 0.0, 0.5
+        with self.wavebank_lock:
+            try:
+                func = self.wavebank.__getattribute__(method)
+            except AttributeError:
+                Logger.error(f"No wavebank method named {method}")
+                return None
+            # Attempt to access the underlying wavebank
+            out = None
+            while timer < timeout:
+                tic = time.time()
+                try:
+                    out = func(*args, **kwargs)
+                    break
+                except (IOError, OSError) as e:
+                    time.sleep(wait_step)
+                toc = time.time()
+                timer += toc - tic
+            else:
+                Logger.error(
+                    f"Waited {timer} s and could not access the wavebank "
+                    f"due to {e}")
+        return out
+
+    def get_wavebank_stream(self, bulk: List[tuple]) -> Stream:
+        """ processsafe get-waveforms-bulk call """
+        st = self._access_wavebank(
+            method="get_waveforms_bulk", timeout=120., bulk=bulk)
+        return st
 
     def _handle_detections(
         self,
@@ -507,6 +595,9 @@ class RealTimeTribe(Tribe):
                     self._running = True  # Lock tribe
                     start_time = UTCDateTime.now()
                     st = self.rt_client.stream.split().merge()
+                    if self.has_wavebank:
+                        self._access_wavebank(
+                            method="put_waveforms", timeout=120., stream=st)
                     last_data_received = self.rt_client.last_data
                     # Split to remove trailing mask
                     if len(st) == 0:
@@ -529,7 +620,6 @@ class RealTimeTribe(Tribe):
                         self.rt_client.background_stop()
                         self.rt_client.stop()
                         # Get a clean instance just in case
-                        # self.rt_client = self.rt_client.copy(empty_buffer=False)
                         Logger.info("Starting streamer")
                         self._start_streaming()
                         Logger.info("Streamer started")
@@ -864,7 +954,7 @@ class RealTimeTribe(Tribe):
             Logger.warning("No bulk")
             return
         Logger.info(f"Getting stations for backfill: {bulk}")
-        st = self.rt_client.get_wavebank_stream(bulk)
+        st = self.get_wavebank_stream(bulk)
         
         self._number_of_backfillers += 1
 

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -1208,7 +1208,10 @@ def _write_detection(
         os.makedirs(_path)
     _filename = os.path.join(
         _path, detection.detect_time.strftime("%Y%m%dT%H%M%S"))
-    detection.event.write(f"{_filename}.xml", format="QUAKEML")
+    try:
+        detection.event.write(f"{_filename}.xml", format="QUAKEML")
+    except Exception as e:
+        Logger.error(f"Could not write event file due to {e}")
     detection.event.picks.sort(key=lambda p: p.time)
     st = stream.slice(
         detection.event.picks[0].time - 10,
@@ -1217,7 +1220,10 @@ def _write_detection(
         # Make plot
         fig = plot_event(fig=fig, event=detection.event, st=st,
                          length=90, show=False)
-        fig.savefig(f"{_filename}.png")
+        try:
+            fig.savefig(f"{_filename}.png")
+        except Exception as e:
+            Logger.error(f"Could not write plot due to {e}")
         fig.clf()
     if save_waveform:
         st = st.split()
@@ -1226,7 +1232,10 @@ def _write_detection(
               tr.data.dtype.type != numpy.int32:
                 # Ensure data are int32, see https://github.com/obspy/obspy/issues/2683
                 tr.data = tr.data.astype(numpy.int32)
-        st.write(f"{_filename}.ms", format="MSEED")
+        try:
+            st.write(f"{_filename}.ms", format="MSEED")
+        except Exception as e:
+            Logger.error(f"Could not write stream due to {e}")
     return fig
 
 

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -639,6 +639,7 @@ class RealTimeTribe(Tribe):
                     # summary.print_(sum1)
                 except Exception as e:
                     Logger.critical(f"Uncaught error: {e}")
+                    Logger.error(traceback.format_exc())
         finally:
             Logger.critical("Stopping")
             self.stop()

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -322,10 +322,14 @@ class RealTimeTribe(Tribe):
     def _start_streaming(self):
         if not self.rt_client.started:
             self.rt_client.start()
-        for tr_id in self.expected_seed_ids:
-            self.rt_client.select_stream(
-                net=tr_id.split('.')[0], station=tr_id.split('.')[1],
-                selector=tr_id.split('.')[3])
+        if self.rt_client.can_add_streams:
+            for tr_id in self.expected_seed_ids:
+                self.rt_client.select_stream(
+                    net=tr_id.split('.')[0], station=tr_id.split('.')[1],
+                    selector=tr_id.split('.')[3])
+        else:
+            Logger.warning("Client already in streaming mode,"
+                           " cannot add channels")
         if not self.rt_client.streaming:
             self.rt_client.background_run()
             Logger.info("Started real-time streaming")

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -336,6 +336,16 @@ class RealTimeTribe(Tribe):
         else:
             Logger.info("Real-time streaming already running")
 
+    def _runtime_check(self, run_start, max_run_length):
+        run_time = UTCDateTime.now() - run_start
+        Logger.info(
+            f"Run time: {run_time:.2f}s, max_run_length: {max_run_length:.2f}s")
+        if max_run_length and run_time > max_run_length:
+            Logger.critical("Hit maximum run time, stopping.")
+            self.stop()
+            return False
+        return True
+
     def run(
         self,
         threshold: float,
@@ -581,6 +591,9 @@ class RealTimeTribe(Tribe):
                             Logger.error("Out of memory, stopping this detector")
                             self.stop()
                             break
+                        if not self._runtime_check(
+                                run_start=run_start, max_run_length=max_run_length):
+                            break
                         Logger.info(
                             "Waiting for {0:.2f}s and hoping this gets "
                             "better".format(self.detect_interval))
@@ -617,9 +630,8 @@ class RealTimeTribe(Tribe):
                     self._wait(
                         wait=(self.detect_interval - run_time) / self._speed_up,
                         detection_kwargs=detection_kwargs)
-                    if max_run_length and UTCDateTime.now() > run_start + max_run_length:
-                        Logger.critical("Hit maximum run time, stopping.")
-                        self.stop()
+                    if not self._runtime_check(
+                            run_start=run_start, max_run_length=max_run_length):
                         break
                     if minimum_rate and UTCDateTime.now() > run_start + self._min_run_length:
                         _rate = average_rate(
@@ -639,6 +651,9 @@ class RealTimeTribe(Tribe):
                     # summary.print_(sum1)
                 except Exception as e:
                     Logger.critical(f"Uncaught error: {e}")
+                    if not self._runtime_check(
+                            run_start=run_start, max_run_length=max_run_length):
+                        break
         finally:
             Logger.critical("Stopping")
             self.stop()

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -1243,7 +1243,10 @@ def _write_detection(
                 tr.data = tr.data.astype(numpy.int32, subok=False)
             if tr.data.dtype.type == numpy.intc:
                 tr.data = tr.data.astype(numpy.int32, subok=False)
-        st.write(f"{_filename}.ms", format="MSEED")
+        try:
+            st.write(f"{_filename}.ms", format="MSEED")
+        except Exception as e:
+            Logger.error(f"Could not write stream due to {e}")
     return fig
 
 

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -1240,9 +1240,9 @@ def _write_detection(
             # Ensure data are int32, see https://github.com/obspy/obspy/issues/2683
             if tr.data.dtype == numpy.int32 and \
               tr.data.dtype.type != numpy.int32:
-                tr.data = tr.data.astype(numpy.int32)
+                tr.data = tr.data.astype(numpy.int32, subok=False)
             if tr.data.dtype.type == numpy.intc:
-                tr.data = tr.data.astype(numpy.int32)
+                tr.data = tr.data.astype(numpy.int32, subok=False)
         st.write(f"{_filename}.ms", format="MSEED")
     return fig
 

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -1011,14 +1011,20 @@ class RealTimeTribe(Tribe):
             starttime, starttime + 2 * self.minimum_data_for_detection)
         while _endtime < endtime + self.minimum_data_for_detection:
             st_chunk = st.slice(_starttime, _endtime)
-            new_party = new_tribe.detect(
-                stream=st_chunk, plot=False, threshold=threshold,
-                threshold_type=threshold_type, trig_int=trig_int,
-                xcorr_func="fftw", concurrency="concurrent",
-                cores=self.max_correlation_cores,
-                parallel_process=self._parallel_processing,
-                process_cores=self.process_cores, copy_data=False,
-                **kwargs)
+            try:
+                new_party = new_tribe.detect(
+                    stream=st_chunk, plot=False, threshold=threshold,
+                    threshold_type=threshold_type, trig_int=trig_int,
+                    xcorr_func="fftw", concurrency="concurrent",
+                    cores=self.max_correlation_cores,
+                    parallel_process=self._parallel_processing,
+                    process_cores=self.process_cores, copy_data=False,
+                    **kwargs)
+            except Exception as e:
+                Logger.error(e)
+                _starttime += self.minimum_data_for_detection
+                _endtime += self.minimum_data_for_detection
+                continue
             detect_directory = detect_directory.format(name=self.name)
             Logger.info(
                 f"Backfill detection between {_starttime} and {_endtime} "

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -93,7 +93,7 @@ class RealTimeTribe(Tribe):
         detect_interval: float = 60.,
         plot: bool = True,
         plot_options: dict = None,
-        wavebank: WaveBank = WaveBank("Streaming_WaveBank"),
+        wavebank: Union[str, WaveBank] = WaveBank("Streaming_WaveBank"),
     ) -> None:
         super().__init__(templates=tribe.templates)
         self.rt_client = rt_client
@@ -114,6 +114,8 @@ class RealTimeTribe(Tribe):
         self.detections = []
 
         # Wavebank status to avoid accessing the underlying, lockable, wavebank
+        if isinstance(wavebank, str):
+            wavebank = WaveBank(wavebank)
         self.__wavebank = wavebank
         if wavebank:
             self.has_wavebank = True

--- a/rt_eqcorrscan/rt_match_filter.py
+++ b/rt_eqcorrscan/rt_match_filter.py
@@ -322,15 +322,11 @@ class RealTimeTribe(Tribe):
     def _start_streaming(self):
         if not self.rt_client.started:
             self.rt_client.start()
-        if self.rt_client.can_add_streams:
-            for tr_id in self.expected_seed_ids:
-                self.rt_client.select_stream(
-                    net=tr_id.split('.')[0], station=tr_id.split('.')[1],
-                    selector=tr_id.split('.')[3])
-        else:
-            Logger.warning("Client already in streaming mode,"
-                           " cannot add channels")
-        if not self.rt_client.busy:
+        for tr_id in self.expected_seed_ids:
+            self.rt_client.select_stream(
+                net=tr_id.split('.')[0], station=tr_id.split('.')[1],
+                selector=tr_id.split('.')[3])
+        if not self.rt_client.streaming:
             self.rt_client.background_run()
             Logger.info("Started real-time streaming")
         else:

--- a/rt_eqcorrscan/streaming/buffers.py
+++ b/rt_eqcorrscan/streaming/buffers.py
@@ -398,7 +398,7 @@ class NumpyDeque(object):
         else:
             mask_value = np.zeros(length)
         self._data[-length:] = data[-length:]
-        self._mask = np.zeros_like(self._data, dtype=np.bool)
+        self._mask = np.zeros_like(self._data, dtype=bool)
         self._mask[0:-length] = np.ones(maxlen - length)
         self._mask[-length:] = mask_value
 

--- a/rt_eqcorrscan/streaming/clients/obsplus.py
+++ b/rt_eqcorrscan/streaming/clients/obsplus.py
@@ -61,7 +61,7 @@ class RealTimeClient(OBSRTCli):
         super().__init__(
             server_url=server_url, starttime=starttime, client=client,
             query_interval=query_interval, speed_up=speed_up, buffer=buffer,
-            buffer_capacity=buffer_capacity, wavebank=None)
+            buffer_capacity=buffer_capacity)
 
 
 if __name__ == "__main__":

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -133,7 +133,7 @@ class RealTimeClient(_StreamingClient):
         now = copy.deepcopy(self.starttime)
         self.last_data = UTCDateTime.now()
         last_query_start = now - self.query_interval
-        while self.streaming:
+        while not self._stop_called:
             # If this is running in a process then we need to check the queue
             try:
                 kill = self._killer_queue.get(block=False)
@@ -174,11 +174,11 @@ class RealTimeClient(_StreamingClient):
             now += max(self.query_interval, _query_duration)
             if query_passed:
                 last_query_start = min(_bulk["endtime"] for _bulk in self.bulk)
+        self.streaming = False
         return
 
     def stop(self) -> None:
         self._stop_called = True
-        self.busy = False
         self.streaming = False
         self.started = False
 

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -134,10 +134,11 @@ class RealTimeClient(_StreamingClient):
                 kill = self._killer_queue.get(block=False)
             except Empty:
                 kill = False
+            Logger.info(f"Kill status: {kill}")
             if kill:
                 Logger.warning("Termination called, stopping collect loop")
                 self.on_terminate()
-                return
+                break
             _query_start = UTCDateTime.now()
             st = Stream()
             query_passed = True
@@ -175,9 +176,8 @@ class RealTimeClient(_StreamingClient):
         return
 
     def stop(self) -> None:
-        self._stop_called = True
-        self.streaming = False
-        self.started = False
+        Logger.info("STOP!")
+        self._stop_called, self.started = True, False
 
 
 if __name__ == "__main__":

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -158,6 +158,8 @@ class RealTimeClient(_StreamingClient):
                     continue
             for tr in st:
                 self.on_data(tr)
+            # Put the data in the buffer
+            self._add_data_from_queue()
             _query_duration = UTCDateTime.now() - _query_start
             Logger.debug(
                 "It took {0:.2f}s to query the database and sort data".format(

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -49,6 +49,7 @@ class RealTimeClient(_StreamingClient):
         Length of buffer in seconds. Old data are removed in a FIFO style.
     """
     client_base = "obspy.clients"
+    can_add_streams = True
 
     def __init__(
         self,
@@ -104,10 +105,6 @@ class RealTimeClient(_StreamingClient):
             query_interval=self.query_interval, speed_up=self.speed_up,
             buffer=buffer, buffer_capacity=self.buffer_capacity,
             wavebank=self.wavebank)
-
-    @property
-    def can_add_streams(self) -> bool:
-        return True  # We can always add streams
 
     def select_stream(self, net: str, station: str, selector: str) -> None:
         """

--- a/rt_eqcorrscan/streaming/clients/obspy.py
+++ b/rt_eqcorrscan/streaming/clients/obspy.py
@@ -61,7 +61,6 @@ class RealTimeClient(_StreamingClient):
         speed_up: float = 1.,
         buffer: Stream = None,
         buffer_capacity: float = 600.,
-        wavebank: WaveBank = None,
     ) -> None:
         if client is None:
             try:
@@ -74,7 +73,7 @@ class RealTimeClient(_StreamingClient):
         self.client = client
         super().__init__(
             server_url=self.client.base_url, buffer=buffer,
-            buffer_capacity=buffer_capacity, wavebank=wavebank)
+            buffer_capacity=buffer_capacity)
         self.starttime = starttime
         self.query_interval = query_interval
         self.speed_up = speed_up
@@ -103,8 +102,7 @@ class RealTimeClient(_StreamingClient):
             server_url=self.client.base_url,
             client=self.client, starttime=self.starttime,
             query_interval=self.query_interval, speed_up=self.speed_up,
-            buffer=buffer, buffer_capacity=self.buffer_capacity,
-            wavebank=self.wavebank)
+            buffer=buffer, buffer_capacity=self.buffer_capacity)
 
     def select_stream(self, net: str, station: str, selector: str) -> None:
         """

--- a/rt_eqcorrscan/streaming/clients/seedlink.py
+++ b/rt_eqcorrscan/streaming/clients/seedlink.py
@@ -41,13 +41,12 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         server_url: str,
         buffer: Stream = None,
         buffer_capacity: float = 600.,
-        wavebank: WaveBank = None,
     ) -> None:
         EasySeedLinkClient.__init__(
             self, server_url=server_url, autoconnect=False)
         _StreamingClient.__init__(
             self, server_url=server_url, buffer=buffer,
-            buffer_capacity=buffer_capacity, wavebank=wavebank)
+            buffer_capacity=buffer_capacity)
         self.conn.keepalive = 0
         self.conn.netdly = 30
         Logger.debug("Instantiated RealTime client: {0}".format(self))
@@ -163,7 +162,7 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
             buffer = self.stream
         return RealTimeClient(
             server_url=self.server_hostname, buffer=buffer,
-            buffer_capacity=self.buffer_capacity, wavebank=self.wavebank)
+            buffer_capacity=self.buffer_capacity)
 
     def start(self) -> None:
         """ Start the connection. """

--- a/rt_eqcorrscan/streaming/clients/seedlink.py
+++ b/rt_eqcorrscan/streaming/clients/seedlink.py
@@ -111,9 +111,10 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
                 kill = False
             if kill:
                 Logger.warning(
-                    "Run termination called - poison received is set.")
+                    "Run termination called - poison received.")
                 self.on_terminate()
-                return
+                self._stop_called = True
+                break
 
             if data == SLPacket.SLTERMINATE:
                 Logger.warning("Received Terminate request from host")
@@ -145,6 +146,7 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
 
         # If we get to here, stop has been called so we can terminate
         self.on_terminate()
+        self.streaming = False
         return
 
     def copy(self, empty_buffer: bool = True):
@@ -215,7 +217,6 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         Logger.info("Closing connection")
         self.close()
         Logger.info("Stopped Streamer")
-        self.streaming = False
 
     def on_seedlink_error(self):  # pragma: no cover
         """ Cope with seedlink errors."""

--- a/rt_eqcorrscan/streaming/clients/seedlink.py
+++ b/rt_eqcorrscan/streaming/clients/seedlink.py
@@ -87,6 +87,7 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         This is an edited version of EasySeedlinkClient from ObsPy allowing
         for connection closure from another process.
         """
+        self.can_add_streams = False
         # Note: This somewhat resembles the run() method in SLClient.
 
         # Check if any streams have been specified (otherwise this will result
@@ -192,10 +193,6 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         Logger.warning("RESTART: Starting the streamer")
         self.start()
         Logger.warning("RESTART: Completed restart")
-
-    @property
-    def can_add_streams(self) -> bool:
-        return not self.streaming
 
     def select_stream(self, net: str, station: str, selector: str = None):
         """

--- a/rt_eqcorrscan/streaming/clients/seedlink.py
+++ b/rt_eqcorrscan/streaming/clients/seedlink.py
@@ -226,21 +226,6 @@ class RealTimeClient(_StreamingClient, EasySeedLinkClient):
         Logger.info("Stopped Streamer")
         self._stop_called = False
 
-    def on_terminate(self) -> Stream:  # pragma: no cover
-        """
-        Handle termination gracefully
-        """
-        st = self.stream
-        Logger.info("Termination of {0}".format(self.__repr__()))
-        if not self._stop_called:  # Make sure we don't double-call stop methods
-            if len(self.processes):
-                self.background_stop()
-            else:
-                self.stop()
-        else:
-            Logger.info("Stop already called - not duplicating")
-        return st
-
     def on_seedlink_error(self):  # pragma: no cover
         """ Cope with seedlink errors."""
         self.on_error()

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -54,6 +54,7 @@ class _StreamingClient(ABC):
     has_wavebank = False
     __last_data = None
     _stop_called = False
+    _wavebank_warned = False
 
     def __init__(
         self,
@@ -222,7 +223,9 @@ class _StreamingClient(ABC):
         Whatever should be returned by the method.
         """
         if not self.has_wavebank:
-            Logger.error("No wavebank attached to streamer")
+            if not self._wavebank_warned:
+                Logger.error("No wavebank attached to streamer")
+                self._wavebank_warned = True
             return None
         timer, wait_step = 0.0, 0.5
         with self.wavebank_lock:

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -53,7 +53,6 @@ class _StreamingClient(ABC):
     lock = multiprocessing.Lock()  # Lock for buffer access
     wavebank_lock = multiprocessing.Lock()
     has_wavebank = False
-    __last_data = None
     _stop_called = False
 
     def __init__(
@@ -354,7 +353,11 @@ class _StreamingClient(ABC):
     def background_stop(self):
         """Stop the background process."""
         Logger.info("Adding Poison to Kill Queue")
+        # Run communications before termination
         st = self.stream
+        self.__buffer_full = self.buffer_full
+        self.__last_data = self.last_data
+
         Logger.debug(f"Stream on termination: {st}")
         self._killer_queue.put(True)
         self.stop()

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -11,6 +11,7 @@ License
 import logging
 import time
 import numpy as np
+import warnings
 
 from abc import ABC, abstractmethod
 from typing import Union
@@ -21,7 +22,10 @@ from obspy import Stream, Trace, UTCDateTime
 from rt_eqcorrscan.streaming.buffers import Buffer
 
 import platform
-if platform.system() == "Windows":
+if platform.system() != "Linux":
+    warnings.warn("Currently Process-based streaming is only supported on "
+                  "Linux, defaulting to Thread-based streaming - you may run "
+                  "into issues when detecting frequently")
     import threading as multiprocessing
     from queue import Queue
     from threading import Thread as Process

--- a/rt_eqcorrscan/streaming/streaming.py
+++ b/rt_eqcorrscan/streaming/streaming.py
@@ -49,6 +49,7 @@ class _StreamingClient(ABC):
     """
     streaming = False
     started = False
+    can_add_streams = True
     lock = multiprocessing.Lock()  # Lock for buffer access
     wavebank_lock = multiprocessing.Lock()
     has_wavebank = False
@@ -126,11 +127,6 @@ class _StreamingClient(ABC):
     @abstractmethod
     def stop(self) -> None:
         """ Stop the system. """
-
-    @property
-    @abstractmethod
-    def can_add_streams(self) -> bool:
-        """ Whether streams can be added."""
 
     @property
     def buffer(self) -> Buffer:
@@ -337,7 +333,7 @@ class _StreamingClient(ABC):
 
     def background_run(self):
         """Run the client in the background."""
-        self.streaming, self.started = True, True
+        self.streaming, self.started, self.can_add_streams = True, True, False
         self._clear_killer()   # Clear the kill queue
         streaming_process = multiprocessing.Process(
             target=self._bg_run, name="StreamProcess")

--- a/tests/plotting_tests/plot_buffer_test.py
+++ b/tests/plotting_tests/plot_buffer_test.py
@@ -66,7 +66,7 @@ class SeedLinkTest(unittest.TestCase):
                 net=net, station=station, selector=selector)
 
         rt_client.background_run()
-        while len(rt_client.buffer) < 7:
+        while len(rt_client.stream) < 7:
             # Wait until we have some data
             time.sleep(SLEEP_STEP)
 

--- a/tests/streaming_tests/long_streamer_test.py
+++ b/tests/streaming_tests/long_streamer_test.py
@@ -55,13 +55,13 @@ class LongSeedLinkTest(unittest.TestCase):
             time.sleep(SLEEP_INTERVAL)
             now = UTCDateTime.now()
             st = rt_client.stream.split().merge()
-            logger.info(f"Currently have the stream: \n{st}")
+            logger.info(f"Currently (at {now}) have the stream: \n{st}")
             for tr in st:
                 if np.ma.is_masked(tr.data):
                     # Check that the data are not super gappy.
                     self.assertLess(tr.data.mask.sum(), len(tr.data) / 4)
                 # Check that data are recent.
-                self.assertLess(abs(now - tr.stats.endtime), 20.0)
+                self.assertLess(abs(now - tr.stats.endtime), 40.0)
             sleepy_time += SLEEP_INTERVAL
         rt_client.background_stop()
 

--- a/tests/streaming_tests/long_streamer_test.py
+++ b/tests/streaming_tests/long_streamer_test.py
@@ -1,0 +1,82 @@
+"""
+Long running test to make sure that streamers can consistently get data.
+"""
+
+
+import unittest
+import time
+import numpy as np
+import os
+
+from obspy import UTCDateTime
+from obsplus import WaveBank
+
+from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
+
+import logging
+
+logging.basicConfig(
+    level="INFO",
+    format="%(asctime)s\t[%(processName)s:%(threadName)s]: %(name)s\t%(levelname)s\t%(message)s")
+
+RUN_LENGTH = 600.0    # Run length in seconds.
+SLEEP_INTERVAL = 30.0  # Interval to check the stream at.
+
+
+@unittest.skipIf("CI" in os.environ and os.environ["CI"] == "true",
+                 "Skipping this test on CI.")
+class LongSeedLinkTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rt_client = RealTimeClient(
+            server_url="link.geonet.org.nz", buffer_capacity=600.)
+        cls.selectors = [
+            ("NZ", "FOZ", "HHZ"),
+            ("NZ", "JCZ", "HHZ"),
+            ("NZ", "WVZ", "HHZ"),
+            ("NZ", "RPZ", "HHZ"),
+            ("NZ", "PYZ", "HHZ"),
+            ("NZ", "URZ", "HHZ"),
+            ("NZ", "WEL", "HHZ"),
+            ("NZ", "INZ", "HHZ"),
+            ("NZ", "APZ", "HHZ"),
+            ("NZ", "SYZ", "HHZ"),
+            ("NZ", "MQZ", "HHZ"),
+        ]
+        cls.clients = []
+
+    def run_streamer(self, rt_client, logger):
+        for net, sta, chan in self.selectors:
+            rt_client.select_stream(net=net, station=sta, selector=chan)
+
+        rt_client.background_run()
+        sleepy_time = 0
+        while sleepy_time <= RUN_LENGTH:
+            time.sleep(SLEEP_INTERVAL)
+            now = UTCDateTime.now()
+            st = rt_client.stream.split().merge()
+            logger.info(f"Currently have the stream: \n{st}")
+            for tr in st:
+                if np.ma.is_masked(tr.data):
+                    # Check that the data are not super gappy.
+                    self.assertLess(tr.data.mask.sum(), len(tr.data) / 4)
+                # Check that data are recent.
+                self.assertLess(abs(now - tr.stats.endtime), 20.0)
+            sleepy_time += SLEEP_INTERVAL
+        rt_client.background_stop()
+
+    def test_no_wavebank(self):
+        """ Run without a wavebank. """
+        logger = logging.getLogger("NoWaveBank")
+        rt_client = self.rt_client.copy()
+        self.clients.append(rt_client)
+        self.run_streamer(rt_client=rt_client, logger=logger)
+
+    @classmethod
+    def tearDownClass(cls):
+        for rt_client in cls.clients:
+            rt_client.background_stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/streaming_tests/long_streamer_test.py
+++ b/tests/streaming_tests/long_streamer_test.py
@@ -61,7 +61,7 @@ class LongSeedLinkTest(unittest.TestCase):
                     # Check that the data are not super gappy.
                     self.assertLess(tr.data.mask.sum(), len(tr.data) / 4)
                 # Check that data are recent.
-                self.assertLess(abs(now - tr.stats.endtime), 40.0)
+                self.assertLess(abs(now - tr.stats.endtime), 60.0)
             sleepy_time += SLEEP_INTERVAL
         rt_client.background_stop()
 

--- a/tests/streaming_tests/obspy_simulate_test.py
+++ b/tests/streaming_tests/obspy_simulate_test.py
@@ -26,24 +26,24 @@ class FDSNTest(unittest.TestCase):
             server_url="Unreal-streamer",
             client=cls.client, buffer_capacity=10,
             starttime=UTCDateTime(2017, 1, 1), speed_up=4., query_interval=5.)
-        cls.clients = [cls.rt_client]
 
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)  # To allow tear-down
         rt_client.select_stream(net="NZ", station="JCZ", selector="HHZ")
         rt_client.background_run()
-        self.assertFalse(rt_client.buffer_full)
+        try:
+            self.assertFalse(rt_client.buffer_full)
+        except Exception as e:
+            rt_client.background_stop()
+            raise e
         time.sleep(SLEEP_STEP)
         rt_client.background_stop()
-        print(rt_client.stream)
         self.assertTrue(rt_client.buffer_full)
         self.assertEqual(rt_client.buffer_length,
                          rt_client.buffer_capacity)
 
     def test_always_started(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)  # To allow tear-down
         rt_client.start()
         self.assertTrue(rt_client.started)
         rt_client.stop()
@@ -73,13 +73,6 @@ class FDSNTest(unittest.TestCase):
                                     "status: Stopped, buffer capacity: 10.0s\n	"
                                     "Current Buffer:\nBuffer(0 traces, "
                                     "maxlen=10)")
-
-    # @classmethod
-    # def tearDownClass(cls):
-    #     n = len(cls.clients)
-    #     for i, rt_client in enumerate(cls.clients):
-    #         print(f"Killing client {i + 1} of {n}")
-    #         rt_client.background_stop()
 
 
 if __name__ == "__main__":

--- a/tests/streaming_tests/obspy_simulate_test.py
+++ b/tests/streaming_tests/obspy_simulate_test.py
@@ -21,27 +21,23 @@ class FDSNTest(unittest.TestCase):
             server_url="Unreal-streamer",
             client=cls.client, buffer_capacity=10,
             starttime=UTCDateTime(2017, 1, 1), speed_up=4., query_interval=5.)
+        cls.clients = [cls.rt_client]
 
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
-        rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
-        rt_client.background_run()
-        time.sleep(SLEEP_STEP)
-        rt_client.background_stop()
-        self.assertEqual(rt_client.buffer_length,
-                         rt_client.buffer_capacity)
-
-    def test_full_buffer(self):
-        rt_client = self.rt_client.copy()
+        self.clients.append(rt_client)  # To allow tear-down
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
         self.assertFalse(rt_client.buffer_full)
         time.sleep(SLEEP_STEP)
-        rt_client.background_stop()
         self.assertTrue(rt_client.buffer_full)
+        rt_client.background_stop()
+        self.assertEqual(rt_client.buffer_length,
+                         rt_client.buffer_capacity)
 
     def test_always_started(self):
         rt_client = self.rt_client.copy()
+        self.clients.append(rt_client)  # To allow tear-down
         rt_client.start()
         self.assertTrue(rt_client.started)
         rt_client.stop()
@@ -71,6 +67,13 @@ class FDSNTest(unittest.TestCase):
                                     "status: Stopped, buffer capacity: 10.0s\n	"
                                     "Current Buffer:\nBuffer(0 traces, "
                                     "maxlen=10)")
+
+    @classmethod
+    def tearDownClass(cls):
+        n = len(cls.clients)
+        for i, rt_client in enumerate(cls.clients):
+            print(f"Killing client {i + 1} of {n}")
+            rt_client.background_stop()
 
 
 if __name__ == "__main__":

--- a/tests/streaming_tests/obspy_simulate_test.py
+++ b/tests/streaming_tests/obspy_simulate_test.py
@@ -4,13 +4,18 @@ Tests for simulating a real-time client.
 
 import unittest
 import time
+import logging
 
 from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
 
 from rt_eqcorrscan.streaming.clients.obspy import RealTimeClient
 
-SLEEP_STEP = 60
+SLEEP_STEP = 20
+
+logging.basicConfig(
+    level="INFO",
+    format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
 
 
 class FDSNTest(unittest.TestCase):
@@ -26,12 +31,13 @@ class FDSNTest(unittest.TestCase):
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
         self.clients.append(rt_client)  # To allow tear-down
-        rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
+        rt_client.select_stream(net="NZ", station="JCZ", selector="HHZ")
         rt_client.background_run()
         self.assertFalse(rt_client.buffer_full)
         time.sleep(SLEEP_STEP)
-        self.assertTrue(rt_client.buffer_full)
         rt_client.background_stop()
+        print(rt_client.stream)
+        self.assertTrue(rt_client.buffer_full)
         self.assertEqual(rt_client.buffer_length,
                          rt_client.buffer_capacity)
 
@@ -68,12 +74,12 @@ class FDSNTest(unittest.TestCase):
                                     "Current Buffer:\nBuffer(0 traces, "
                                     "maxlen=10)")
 
-    @classmethod
-    def tearDownClass(cls):
-        n = len(cls.clients)
-        for i, rt_client in enumerate(cls.clients):
-            print(f"Killing client {i + 1} of {n}")
-            rt_client.background_stop()
+    # @classmethod
+    # def tearDownClass(cls):
+    #     n = len(cls.clients)
+    #     for i, rt_client in enumerate(cls.clients):
+    #         print(f"Killing client {i + 1} of {n}")
+    #         rt_client.background_stop()
 
 
 if __name__ == "__main__":

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -18,7 +18,10 @@ logging.basicConfig(
     level="INFO",
     format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
 
+SLEEP_STEP = 30
 
+# Note:: Must always have try: finally: to stop the streamer to avoid
+# continuous running on fail!
 class SeedLinkTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -30,10 +33,12 @@ class SeedLinkTest(unittest.TestCase):
         rt_client = self.rt_client.copy()
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        time.sleep(30)
-        self.assertEqual(rt_client.buffer_length,
-                         rt_client.buffer_capacity)
-        rt_client.background_stop()
+        time.sleep(SLEEP_STEP)
+        try:
+            self.assertEqual(rt_client.buffer_length,
+                             rt_client.buffer_capacity)
+        finally:
+            rt_client.background_stop()
 
     @pytest.mark.flaky(reruns=2)
     def test_full_buffer(self):
@@ -41,10 +46,12 @@ class SeedLinkTest(unittest.TestCase):
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.clear_buffer()
         rt_client.background_run()
-        self.assertFalse(rt_client.buffer_full)
-        time.sleep(30)
-        rt_client.background_stop()
-        self.assertTrue(rt_client.buffer_full)
+        try:
+            self.assertFalse(rt_client.buffer_full)
+            time.sleep(SLEEP_STEP)
+            self.assertTrue(rt_client.buffer_full)
+        finally:
+            rt_client.background_stop()
 
     @pytest.mark.flaky(reruns=2)
     def test_can_add_streams(self):
@@ -52,22 +59,27 @@ class SeedLinkTest(unittest.TestCase):
         self.assertTrue(rt_client.can_add_streams)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        self.assertFalse(rt_client.can_add_streams)
-        rt_client.background_stop()
+        try:
+            self.assertFalse(rt_client.can_add_streams)
+        finally:
+            rt_client.background_stop()
         self.assertFalse(rt_client.can_add_streams)
         rt_client = self.rt_client.copy(empty_buffer=False)
         self.assertTrue(rt_client.can_add_streams)
 
     @pytest.mark.flaky(reruns=2)
     def test_get_stream(self):
+        initial_sleep = 10
         rt_client = self.rt_client.copy()
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        time.sleep(10)
+        time.sleep(initial_sleep)
         stream = rt_client.stream
-        self.assertIsInstance(stream, Stream)
-        time.sleep(20)
-        rt_client.background_stop()
+        try:
+            self.assertIsInstance(stream, Stream)
+            time.sleep(SLEEP_STEP - initial_sleep)
+        finally:
+            rt_client.background_stop()
         stream2 = rt_client.stream
         self.assertNotEqual(stream, stream2)
 
@@ -91,11 +103,11 @@ class SeedLinkThreadedTests(unittest.TestCase):
         rt_client.background_run()
         tic, toc = time.time(), time.time()
         st = Stream()
-        while toc - tic < 20.0:
+        while toc - tic < SLEEP_STEP:
             st = rt_client.stream
             toc = time.time()
         rt_client.background_stop()
-        assert len(st) != 0
+        self.assertNotEqual(len(st), 0)
         # If we got here without error, then we should be safe.
 
     def test_add_trace_from_mainprocess(self):
@@ -104,28 +116,48 @@ class SeedLinkThreadedTests(unittest.TestCase):
             server_url="link.geonet.org.nz", buffer_capacity=600.)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        time.sleep(20)
-        st = rt_client.stream.split()
-        assert len(st) > 0, "Empty Stream, cannot perform test"
+        # Wait for some data to perform the test
+        tic, toc = time.time(), time.time()
+        while toc - tic < SLEEP_STEP:
+            time.sleep(1)
+            st = rt_client.stream.split()
+            if len(st):
+                break
+            toc = time.time()
+        else:
+            rt_client.background_stop()  # Must stop the streamer!
+            raise NotImplementedError("Did not accumulate any data")
         tr = st[0]
         tr.stats.starttime -= 100
         rt_client.on_data(tr)
-        time.sleep(20)
-        rt_client.background_stop()
+        time.sleep(SLEEP_STEP)
         st = rt_client.stream.split().merge()
-        assert len(st) == 1, "More than one trace in stream!"
-        self.assertLess(st[0].stats.starttime - tr.stats.starttime, 0.01)
-        self.assertGreater(st[0].stats.endtime, tr.stats.endtime)
+        try:
+            self.assertEqual(len(st), 1)  # "More than one trace in stream!"
+            self.assertLess(st[0].stats.starttime - tr.stats.starttime, 0.01)
+            self.assertGreater(st[0].stats.endtime, tr.stats.endtime)
+        finally:
+            rt_client.background_stop()
 
     def test_add_data_not_streaming(self):
         rt_client = RealTimeClient(
             server_url="link.geonet.org.nz", buffer_capacity=600.)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        time.sleep(30)
+        # Wait for some data to perform the test
+        tic, toc = time.time(), time.time()
+        while toc - tic < SLEEP_STEP:
+            time.sleep(1)
+            st = rt_client.stream.split()
+            if len(st):
+                break
+            toc = time.time()
+        else:
+            rt_client.background_stop()  # Must stop the streamer!
+            raise NotImplementedError("Did not accumulate any data")
+        # Stop the streamer here.
         rt_client.background_stop()
-        st = rt_client.stream.split().merge()
-        self.assertGreater(len(st), 0)
+
         tr = st[0].copy()
         tr.stats.starttime -= 100
         # Try to add the trace.

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -27,7 +27,7 @@ class SeedLinkTest(unittest.TestCase):
         rt_client = self.rt_client.copy()
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
-        time.sleep(60)
+        time.sleep(30)
         rt_client.background_stop()
         self.assertEqual(rt_client.buffer_length,
                          rt_client.buffer_capacity)
@@ -38,7 +38,7 @@ class SeedLinkTest(unittest.TestCase):
         rt_client.clear_buffer()
         rt_client.background_run()
         self.assertFalse(rt_client.buffer_full)
-        time.sleep(60)
+        time.sleep(30)
         rt_client.background_stop()
         self.assertTrue(rt_client.buffer_full)
 
@@ -70,7 +70,7 @@ class SeedLinkTest(unittest.TestCase):
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.wavebank = WaveBank(base_path="test_wavebank")
         rt_client.background_run()
-        time.sleep(60)
+        time.sleep(30)
         rt_client.background_stop()
         self.assertTrue(rt_client.buffer_full)  # Need a full buffer to work
         wavebank_traces = rt_client.wavebank.get_waveforms()
@@ -117,11 +117,15 @@ class SeedLinkThreadedTests(unittest.TestCase):
         tic, toc = time.time(), time.time()
         st = Stream()
         while toc - tic < 10.0:
-            st = rt_client.stream  # This waits then acquires the lock
+            st = rt_client.stream
             toc = time.time()
         rt_client.background_stop()
         assert len(st) != 0
         # If we got here without error, then we should be safe.
+
+    def test_add_trace_from_mainprocess(self):
+        """ Check that adding a trace from the main process works. """
+        assert False
 
 
 if __name__ == "__main__":

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -15,7 +15,7 @@ from rt_eqcorrscan.streaming.clients.seedlink import RealTimeClient
 import logging
 
 logging.basicConfig(
-    level="DEBUG",
+    level="INFO",
     format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
 
 
@@ -24,38 +24,31 @@ class SeedLinkTest(unittest.TestCase):
     def setUpClass(cls):
         cls.rt_client = RealTimeClient(
             server_url="link.geonet.org.nz", buffer_capacity=10.)
-        cls.clients = [cls.rt_client]
-
-    @classmethod
-    def tearDownClass(cls):
-        for client in cls.clients:
-            client.background_stop()
 
     @pytest.mark.flaky(reruns=2)
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
         time.sleep(30)
         self.assertEqual(rt_client.buffer_length,
                          rt_client.buffer_capacity)
+        rt_client.background_stop()
 
     @pytest.mark.flaky(reruns=2)
     def test_full_buffer(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.clear_buffer()
         rt_client.background_run()
         self.assertFalse(rt_client.buffer_full)
         time.sleep(30)
+        rt_client.background_stop()
         self.assertTrue(rt_client.buffer_full)
 
     @pytest.mark.flaky(reruns=2)
     def test_can_add_streams(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)
         self.assertTrue(rt_client.can_add_streams)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
@@ -68,46 +61,15 @@ class SeedLinkTest(unittest.TestCase):
     @pytest.mark.flaky(reruns=2)
     def test_get_stream(self):
         rt_client = self.rt_client.copy()
-        self.clients.append(rt_client)
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
         rt_client.background_run()
         time.sleep(10)
         stream = rt_client.stream
         self.assertIsInstance(stream, Stream)
         time.sleep(20)
+        rt_client.background_stop()
         stream2 = rt_client.stream
         self.assertNotEqual(stream, stream2)
-
-    # def test_wavebank_integration(self):
-    #     rt_client = self.rt_client.copy()
-    #     rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
-    #     rt_client.wavebank = WaveBank(base_path="test_wavebank")
-    #     rt_client.background_run()
-    #     time.sleep(30)
-    #     rt_client.background_stop()
-    #     self.assertTrue(rt_client.buffer_full)  # Need a full buffer to work
-    #     wavebank_traces = rt_client.wavebank.get_waveforms()
-    #     wavebank_stream = wavebank_traces.merge()
-    #     buffer_stream = rt_client.stream
-    #     wavebank_stream.sort()
-    #     buffer_stream.sort()
-    #     self.assertEqual(buffer_stream[0].id, wavebank_stream[0].id)
-    #     print(buffer_stream[0])
-    #     print(wavebank_stream[0])
-    #     self.assertLessEqual(
-    #         abs(buffer_stream[0].stats.endtime -
-    #             wavebank_stream[0].stats.endtime),
-    #         buffer_stream[0].stats.delta * 10)
-    #     endtime = min(buffer_stream[0].stats.endtime,
-    #                   wavebank_stream[0].stats.endtime)
-    #     starttime = max(buffer_stream[0].stats.starttime,
-    #                     wavebank_stream[0].stats.starttime)
-    #     self.assertTrue(
-    #         np.all(wavebank_stream.slice(
-    #             starttime=starttime, endtime=endtime)[0].data ==
-    #                buffer_stream.slice(
-    #                    starttime=starttime, endtime=endtime)[0].data))
-        # shutil.rmtree("test_wavebank")
 
 
 class SeedLinkThreadedTests(unittest.TestCase):

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -65,35 +65,35 @@ class SeedLinkTest(unittest.TestCase):
         self.assertNotEqual(stream, stream2)
         rt_client.background_stop()
 
-    def test_wavebank_integration(self):
-        rt_client = self.rt_client.copy()
-        rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
-        rt_client.wavebank = WaveBank(base_path="test_wavebank")
-        rt_client.background_run()
-        time.sleep(30)
-        rt_client.background_stop()
-        self.assertTrue(rt_client.buffer_full)  # Need a full buffer to work
-        wavebank_traces = rt_client.wavebank.get_waveforms()
-        wavebank_stream = wavebank_traces.merge()
-        buffer_stream = rt_client.stream
-        wavebank_stream.sort()
-        buffer_stream.sort()
-        self.assertEqual(buffer_stream[0].id, wavebank_stream[0].id)
-        print(buffer_stream[0])
-        print(wavebank_stream[0])
-        self.assertLessEqual(
-            abs(buffer_stream[0].stats.endtime -
-                wavebank_stream[0].stats.endtime),
-            buffer_stream[0].stats.delta * 10)
-        endtime = min(buffer_stream[0].stats.endtime,
-                      wavebank_stream[0].stats.endtime)
-        starttime = max(buffer_stream[0].stats.starttime,
-                        wavebank_stream[0].stats.starttime)
-        self.assertTrue(
-            np.all(wavebank_stream.slice(
-                starttime=starttime, endtime=endtime)[0].data ==
-                   buffer_stream.slice(
-                       starttime=starttime, endtime=endtime)[0].data))
+    # def test_wavebank_integration(self):
+    #     rt_client = self.rt_client.copy()
+    #     rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
+    #     rt_client.wavebank = WaveBank(base_path="test_wavebank")
+    #     rt_client.background_run()
+    #     time.sleep(30)
+    #     rt_client.background_stop()
+    #     self.assertTrue(rt_client.buffer_full)  # Need a full buffer to work
+    #     wavebank_traces = rt_client.wavebank.get_waveforms()
+    #     wavebank_stream = wavebank_traces.merge()
+    #     buffer_stream = rt_client.stream
+    #     wavebank_stream.sort()
+    #     buffer_stream.sort()
+    #     self.assertEqual(buffer_stream[0].id, wavebank_stream[0].id)
+    #     print(buffer_stream[0])
+    #     print(wavebank_stream[0])
+    #     self.assertLessEqual(
+    #         abs(buffer_stream[0].stats.endtime -
+    #             wavebank_stream[0].stats.endtime),
+    #         buffer_stream[0].stats.delta * 10)
+    #     endtime = min(buffer_stream[0].stats.endtime,
+    #                   wavebank_stream[0].stats.endtime)
+    #     starttime = max(buffer_stream[0].stats.starttime,
+    #                     wavebank_stream[0].stats.starttime)
+    #     self.assertTrue(
+    #         np.all(wavebank_stream.slice(
+    #             starttime=starttime, endtime=endtime)[0].data ==
+    #                buffer_stream.slice(
+    #                    starttime=starttime, endtime=endtime)[0].data))
         # shutil.rmtree("test_wavebank")
 
 

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -6,6 +6,7 @@ import unittest
 import time
 import shutil
 import os
+import pytest
 
 from obspy import Stream
 
@@ -30,6 +31,7 @@ class SeedLinkTest(unittest.TestCase):
         for client in cls.clients:
             client.background_stop()
 
+    @pytest.mark.flaky(reruns=2)
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
         self.clients.append(rt_client)
@@ -39,6 +41,7 @@ class SeedLinkTest(unittest.TestCase):
         self.assertEqual(rt_client.buffer_length,
                          rt_client.buffer_capacity)
 
+    @pytest.mark.flaky(reruns=2)
     def test_full_buffer(self):
         rt_client = self.rt_client.copy()
         self.clients.append(rt_client)
@@ -49,6 +52,7 @@ class SeedLinkTest(unittest.TestCase):
         time.sleep(30)
         self.assertTrue(rt_client.buffer_full)
 
+    @pytest.mark.flaky(reruns=2)
     def test_can_add_streams(self):
         rt_client = self.rt_client.copy()
         self.clients.append(rt_client)
@@ -61,6 +65,7 @@ class SeedLinkTest(unittest.TestCase):
         rt_client = self.rt_client.copy(empty_buffer=False)
         self.assertTrue(rt_client.can_add_streams)
 
+    @pytest.mark.flaky(reruns=2)
     def test_get_stream(self):
         rt_client = self.rt_client.copy()
         self.clients.append(rt_client)

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -125,7 +125,22 @@ class SeedLinkThreadedTests(unittest.TestCase):
 
     def test_add_trace_from_mainprocess(self):
         """ Check that adding a trace from the main process works. """
-        assert False
+        rt_client = self.rt_client.copy()
+        rt_client.buffer_capacity = 600  # Set to a long capacity for this
+        rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
+        rt_client.background_run()
+        time.sleep(20)
+        st = rt_client.stream
+        assert len(st) > 0, "Empty Stream, cannot perform test"
+        tr = st[0]
+        tr.stats.starttime -= 100
+        rt_client.on_data(tr)
+        time.sleep(20)
+        rt_client.background_stop()
+        st = rt_client.stream.merge()
+        assert len(st) == 1, "More than one trace in stream!"
+        assert st[0].stats.starttime == tr.stats.starttime
+        assert st[0].stats.endtime > tr.stats.endtime
 
 
 if __name__ == "__main__":

--- a/tests/streaming_tests/seedlink_test.py
+++ b/tests/streaming_tests/seedlink_test.py
@@ -20,6 +20,7 @@ logging.basicConfig(
 
 SLEEP_STEP = 30
 
+
 # Note:: Must always have try: finally: to stop the streamer to avoid
 # continuous running on fail!
 class SeedLinkTest(unittest.TestCase):
@@ -28,7 +29,7 @@ class SeedLinkTest(unittest.TestCase):
         cls.rt_client = RealTimeClient(
             server_url="link.geonet.org.nz", buffer_capacity=10.)
 
-    @pytest.mark.flaky(reruns=2)
+    @pytest.mark.flaky(reruns=1)
     def test_background_streaming(self):
         rt_client = self.rt_client.copy()
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
@@ -40,7 +41,7 @@ class SeedLinkTest(unittest.TestCase):
         finally:
             rt_client.background_stop()
 
-    @pytest.mark.flaky(reruns=2)
+    @pytest.mark.flaky(reruns=1)
     def test_full_buffer(self):
         rt_client = self.rt_client.copy()
         rt_client.select_stream(net="NZ", station="FOZ", selector="HHZ")
@@ -53,7 +54,7 @@ class SeedLinkTest(unittest.TestCase):
         finally:
             rt_client.background_stop()
 
-    @pytest.mark.flaky(reruns=2)
+    @pytest.mark.flaky(reruns=1)
     def test_can_add_streams(self):
         rt_client = self.rt_client.copy()
         self.assertTrue(rt_client.can_add_streams)
@@ -67,7 +68,7 @@ class SeedLinkTest(unittest.TestCase):
         rt_client = self.rt_client.copy(empty_buffer=False)
         self.assertTrue(rt_client.can_add_streams)
 
-    @pytest.mark.flaky(reruns=2)
+    @pytest.mark.flaky(reruns=1)
     def test_get_stream(self):
         initial_sleep = 10
         rt_client = self.rt_client.copy()


### PR DESCRIPTION
I ran into some issues when running multiple `RealTimeTribes` with many templates that data would appear gappy from seedlink clients. I suspect that this was due to the MainProcess hogging the thread-time and not allowing the Streamer any of the Thread.

To get around this I have migrated the Streamers to Processes, with associated Queues for communication. This has been quite complicated!

I'm running a longer-term test with the same settings that resulted in the issue to see if this crops up again...